### PR TITLE
Fixed start script entrypoint

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -25,5 +25,5 @@ else
     source "${APP_DIR}/global_env"
     source "${APP_DIR}/app_env"
 
-    exec node ${APP_DIR}/bin/www.js -- $PORT
+    exec node ${APP_DIR}/server.js -- $PORT
 fi


### PR DESCRIPTION
Entrypoint should be `src/server.ts` which, when compiled and packed, becomes `server.js`.
This PR fixes the start script so it calls the correct entrypoint.