### PR TITLE
Fix CDN_HOST variable type

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -16,7 +16,7 @@ export const env = readEnv(process.env, {
         .default(false),
     CDN_URL_CSS: str.describe("CDN URL for the CSS files").default("/css"),
     CDN_URL_JS: str.describe("CDN URL for the JavaScript files").default("/js"),
-    CDN_HOST: url.describe("URL for the CDN"),
+    CDN_HOST: str.describe("URL for the CDN"),
     NODE_PORT: port.describe("Port to run the web server on").default(3000),
     NODE_HOSTNAME: str
         .describe("Host name the server is hosted on")


### PR DESCRIPTION
CDN_HOST variable doesn't have a protocol and so it fails url validation. 
This PR changes it to be a standard string type.