### PR TITLE
Fix port env var name

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -17,7 +17,7 @@ export const env = readEnv(process.env, {
     CDN_URL_CSS: str.describe("CDN URL for the CSS files").default("/css"),
     CDN_URL_JS: str.describe("CDN URL for the JavaScript files").default("/js"),
     CDN_HOST: str.describe("URL for the CDN"),
-    NODE_PORT: port.describe("Port to run the web server on").default(3000),
+    PORT: port.describe("Port to run the web server on").default(3000),
     NODE_HOSTNAME: str
         .describe("Host name the server is hosted on")
         .default(""),

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,8 +7,8 @@ import { env } from './config';
 
 // start the HTTP server
 const httpServer = http.createServer(app);
-httpServer.listen(env.NODE_PORT, () => {
-    console.log(`Server started at: ${env.NODE_HOSTNAME}:${env.NODE_PORT}`);
+httpServer.listen(env.PORT, () => {
+    console.log(`Server started at: ${env.NODE_HOSTNAME}:${env.PORT}`);
 }).on("error", err => {
     logger.error(`${err.name} - HTTP Server error: ${err.message} - ${err.stack}`);
 });

--- a/start.sh
+++ b/start.sh
@@ -25,5 +25,5 @@ else
     source "${APP_DIR}/global_env"
     source "${APP_DIR}/app_env"
 
-    exec node ${APP_DIR}/server.js -- $PORT
+    exec node ${APP_DIR}/server.js
 fi


### PR DESCRIPTION
- The start script creates the PORT environment variable.
- The application is reading `NODE_PORT` for this purpose.

This PR renames the config variable to `PORT` to match the start script.