### PR TITLE
Removed session middleware from healthcheck endpoint

### DIFF
--- a/src/router.dispatch.ts
+++ b/src/router.dispatch.ts
@@ -1,12 +1,11 @@
 // Do Router dispatch here, i.e. map incoming routes to appropriate router
-import { Application, Router, Request } from "express";
+import { Application, Router } from "express";
 import { servicePathPrefix, COMPANY_AUTH_PROTECTED_BASE, healthcheckUrl, uploadedUrl, submitUrl } from "./utils/constants/urls";
 import { HomeRouter, HealthCheckRouter, FileUpladedRouter, SubmitRouter } from "./routers";
 import { errorHandler, pageNotFound } from "./routers/handlers/errors";
 import { authenticationMiddleware } from "./middleware/authentication.middleware";
 import { commonTemplateVariablesMiddleware } from "./middleware/common.variables.middleware";
 import { companyAuthenticationMiddleware } from "./middleware/company.authentication.middleware";
-import { getRelativeUrl, skipIf } from "./utils";
 import { sessionMiddleware } from "./middleware/session.middleware";
 
 const routerDispatch = (app: Application) => {
@@ -14,15 +13,17 @@ const routerDispatch = (app: Application) => {
     const router = Router();
     app.use(servicePathPrefix, router);
 
-    router.use('/', sessionMiddleware);
-    // ------------- Enable login redirect -----------------
-    const userAuthRegex = new RegExp("^/.+");
-    const isHealthCheckEndpoint = (req: Request) => getRelativeUrl(req).startsWith(healthcheckUrl);
-    router.use(userAuthRegex, skipIf(isHealthCheckEndpoint, authenticationMiddleware));
-    router.use(`${COMPANY_AUTH_PROTECTED_BASE}`, companyAuthenticationMiddleware);
-
+    // Routes that do not require auth or session are added to the router before the sessiona and auth middlewares
     router.use("/", HomeRouter);
     router.use(healthcheckUrl, HealthCheckRouter);
+
+    router.use('/', sessionMiddleware);
+
+    // ------------- Enable login redirect -----------------
+    const userAuthRegex = new RegExp("^/.+");
+    router.use(userAuthRegex, authenticationMiddleware);
+    router.use(`${COMPANY_AUTH_PROTECTED_BASE}`, companyAuthenticationMiddleware);
+
     router.use(uploadedUrl, FileUpladedRouter);
     router.use(submitUrl, SubmitRouter );
 

--- a/src/router.dispatch.ts
+++ b/src/router.dispatch.ts
@@ -13,7 +13,7 @@ const routerDispatch = (app: Application) => {
     const router = Router();
     app.use(servicePathPrefix, router);
 
-    // Routes that do not require auth or session are added to the router before the sessiona and auth middlewares
+    // Routes that do not require auth or session are added to the router before the session and auth middlewares
     router.use("/", HomeRouter);
     router.use(healthcheckUrl, HealthCheckRouter);
 


### PR DESCRIPTION
The session handler was being applied to the healthcheck endpoint.
This lead to log pollution making resolving issues difficult as the healthcheck endpoint is polled very frequently.

This PR moves the healthcheck endpoint so it is attached to the router before the session middleware meaning the session middleware is not applied to it.