### PR TITLE
Make lb match path without slash

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -6,7 +6,7 @@ locals {
   container_port            = "3000" # default node port required here until prod docker container is built allowing port change via env var
   docker_repo               = "accounts-filing-web"
   lb_listener_rule_priority = 16
-  lb_listener_paths         = ["/accounts-filing/*"]
+  lb_listener_paths         = ["/accounts-filing*"]
   healthcheck_path          = "/accounts-filing/healthcheck" #healthcheck path for accounts-filing-web
   healthcheck_matcher       = "200"                        # no explicit healthcheck in this service yet, change this when added!
 


### PR DESCRIPTION
Old LB path only matched `/accounts-filing/` and any sub paths.
This PR removes the trailing slash so that `/accounts-filing` matches for the home page.