### PR TITLE
Add validator back button

### DIFF
--- a/src/routers/handlers/submit/submit.ts
+++ b/src/routers/handlers/submit/submit.ts
@@ -21,7 +21,8 @@ export class SubmitHandler extends GenericHandler {
 
 export function getFileUploadUrl(req: Request): string{
     const zipPortalBaseURL = `${req.protocol}://${req.get('host')}`;
-    const zipPortalCallbackUrl = zipPortalBaseURL + servicePathPrefix + uploadedUrl + `/${fileIdPlaceholder}`;
+    const zipPortalCallbackUrl = encodeURIComponent(`${zipPortalBaseURL}${servicePathPrefix}${uploadedUrl}/${fileIdPlaceholder}`);
+    const xbrlValidatorBackUrl = encodeURIComponent(zipPortalBaseURL + servicePathPrefix);
 
-    return `${env.SUBMIT_VALIDATION_URL}?callback=${encodeURIComponent(zipPortalCallbackUrl)}`;
+    return `${env.SUBMIT_VALIDATION_URL}?callback=${zipPortalCallbackUrl}&backUrl=${xbrlValidatorBackUrl}`;
 }

--- a/src/routers/handlers/uploaded/uploaded.ts
+++ b/src/routers/handlers/uploaded/uploaded.ts
@@ -6,7 +6,7 @@ import { AccountsFilingService } from "../../../services/external/accounts.filin
 import { AccountValidatorResponse } from "private-api-sdk-node/dist/services/account-validator/types";
 import { AccountsFilingValidationRequest } from "private-api-sdk-node/dist/services/accounts-filing/types";
 import { getFileUploadUrl } from "../submit/submit";
-import { ContextKeys } from "utils/constants/context.keys";
+import { ContextKeys } from "../../../utils/constants/context.keys";
 
 /**
  * Interface representing the view data for an uploaded file, extending from BaseViewData.

--- a/src/routers/handlers/uploaded/uploaded.ts
+++ b/src/routers/handlers/uploaded/uploaded.ts
@@ -6,6 +6,7 @@ import { AccountsFilingService } from "../../../services/external/accounts.filin
 import { AccountValidatorResponse } from "private-api-sdk-node/dist/services/account-validator/types";
 import { AccountsFilingValidationRequest } from "private-api-sdk-node/dist/services/accounts-filing/types";
 import { getFileUploadUrl } from "../submit/submit";
+import { ContextKeys } from "utils/constants/context.keys";
 
 /**
  * Interface representing the view data for an uploaded file, extending from BaseViewData.
@@ -48,9 +49,9 @@ export class UploadedHandler extends GenericHandler {
         const fileId = req.params.fileId;
         // TODO: remove nullish coalescing once the variables have been populated.
         const accountsFilingId =
-            req.session?.getExtraData<string>("accountsFilingId") ?? "Placeholder accountsFilingId";
+            req.session?.getExtraData<string>(ContextKeys.ACCOUNTS_FILING_ID) ?? "Placeholder accountsFilingId";
         const transactionId =
-            req.session?.getExtraData<string>("transactionId") ?? "Placeholder transactionId";
+            req.session?.getExtraData<string>(ContextKeys.TRANSACTION_ID) ?? "Placeholder transactionId";
 
         const validationRequest = {
             fileId,

--- a/src/routers/submit.router.ts
+++ b/src/routers/submit.router.ts
@@ -5,8 +5,8 @@ const router: Router = Router();
 
 router.get('/', (req: Request, res: Response, _next: NextFunction) => {
     const submitHandler = new SubmitHandler();
-    const validatorRedriectUrl = submitHandler.execute(req, res);
-    res.redirect(validatorRedriectUrl);
+    const validatorRedirectUrl = submitHandler.execute(req, res);
+    res.redirect(validatorRedirectUrl);
 });
 
 export default router;

--- a/src/routers/submit.router.ts
+++ b/src/routers/submit.router.ts
@@ -5,8 +5,8 @@ const router: Router = Router();
 
 router.get('/', (req: Request, res: Response, _next: NextFunction) => {
     const submitHandler = new SubmitHandler();
-    const callbackUrl = submitHandler.execute(req, res);
-    res.redirect(callbackUrl);
+    const validatorRedriectUrl = submitHandler.execute(req, res);
+    res.redirect(validatorRedriectUrl);
 });
 
 export default router;

--- a/src/utils/constants/context.keys.ts
+++ b/src/utils/constants/context.keys.ts
@@ -1,0 +1,4 @@
+export const ContextKeys = {
+    ACCOUNTS_FILING_ID: "accountsFilingId",
+    TRANSACTION_ID: "transactionId"
+};


### PR DESCRIPTION
When redirecting to the account validator to upload the accounts file, the submit pages back button went back to xbrl account validator instead of the accounts filing web home page. 

This PR passes the previous pages url via a query parameter in the valdator redirect url.
Here is the related `account-validator-web` pr to handle this query parameter: https://github.com/companieshouse/account-validator-web/pull/107.

