### PR TITLE
Add call to set package type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "govuk-frontend": "^4.7.0",
         "ioredis": "^5.3.2",
         "nunjucks": "^3.2.4",
-        "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#1.0.11",
+        "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#1.0.12",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -8567,7 +8567,7 @@
     },
     "node_modules/private-api-sdk-node": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#99127ac1179dfee5b6f49f039a4fd813ceaf47ad",
+      "resolved": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#86ff44047e11a993722a546baee5c100ffabbfa8",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -68,13 +68,13 @@
     "@companieshouse/api-sdk-node": "^2.0.136",
     "@companieshouse/node-session-handler": "^5.0.1",
     "@companieshouse/structured-logging-node": "^2.0.1",
-    "@companieshouse/web-security-node": "^2.0.5", 
+    "@companieshouse/web-security-node": "^2.0.5",
     "cookie-parser": "^1.4.6",
     "express": "^4.18.2",
     "govuk-frontend": "^4.7.0",
     "ioredis": "^5.3.2",
     "nunjucks": "^3.2.4",
-    "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#1.0.11",
+    "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#1.0.12",
     "uuid": "^9.0.1"
   },
   "overrides": {

--- a/src/routers/handlers/upload/upload.ts
+++ b/src/routers/handlers/upload/upload.ts
@@ -1,13 +1,13 @@
 import { logger } from "../../../utils/logger";
 import { GenericHandler } from "../generic";
 import {
-    servicePathPrefix,
+    PrefixedUrls,
 } from "../../../utils/constants/urls";
 import { Request, Response } from "express";
 import { ContextKeys } from "../../../utils/constants/context.keys";
 import { TransactionService } from "../../../services/external/transaction.service";
 import { AccountsFilingService } from "services/external/accounts.filing.service";
-import { getCompanyNumber, must } from "../../../utils/session";
+import { getCompanyNumber,  must } from "../../../utils/session";
 import { TRANSACTION_DESCRIPTION, TRANSACTION_REFERENCE } from "../../../utils/constants/transaction";
 import { constructValidatorRedirect } from "../../../utils/url";
 
@@ -15,7 +15,7 @@ export class UploadHandler extends GenericHandler {
     constructor(private accountsFilingService: AccountsFilingService, private transactionService: TransactionService) {
         super({
             title: '',
-            backURL: `${servicePathPrefix}`
+            backURL: PrefixedUrls.HOME
         });
     }
 
@@ -50,6 +50,8 @@ export class UploadHandler extends GenericHandler {
             throw error;
         }
 
+        await this.accountsFilingService.setPackageAccountsType(req.session, "UKSEF");
+
         return constructValidatorRedirect(req);
     }
 
@@ -62,7 +64,5 @@ export class UploadHandler extends GenericHandler {
             return undefined;
         }
     }
-
-
 }
 

--- a/test/services/external/accounts.filing.service.unit.ts
+++ b/test/services/external/accounts.filing.service.unit.ts
@@ -1,8 +1,11 @@
 import PrivateApiClient from 'private-api-sdk-node/dist/client';
 import { AccountsFilingService } from '../../../src/services/external/accounts.filing.service';
 import { Resource } from '@companieshouse/api-sdk-node';
-import { AccountsFileValidationResponse, AccountsFilingCompanyResponse, AccountsFilingValidationRequest } from 'private-api-sdk-node/dist/services/accounts-filing/types';
+import { AccountsFileValidationResponse, AccountsFilingCompanyResponse, AccountsFilingValidationRequest, PackageAccountsType } from 'private-api-sdk-node/dist/services/accounts-filing/types';
 import { ApiErrorResponse } from '@companieshouse/api-sdk-node/dist/services/resource';
+import { Failure, Result, Success } from '@companieshouse/api-sdk-node/dist/services/result';
+import { Session } from '@companieshouse/node-session-handler';
+import { ContextKeys } from '../../../src/utils/constants/context.keys';
 
 jest.mock('private-api-sdk-node/dist/client', () => {
     return jest.fn().mockImplementation(() => {
@@ -120,4 +123,68 @@ describe('AccountsFilingService', () => {
         await expect(service.checkCompany(companyNumber, transactionId)).rejects.toEqual(mockErrorResponse);
     });
 
+
+    describe("AccountsFilingService.setPackageAccountsType tests", () => {
+        let service: AccountsFilingService;
+        const mockSetPackageAccountsType = jest.fn<Promise<Result<void, Error>>, [string, string, PackageAccountsType]>();
+        let session: Session;
+
+        const mockTransactionId = (txId: string) => {
+            session.setExtraData(ContextKeys.TRANSACTION_ID, txId);
+        };
+
+        const mockaccountsFilingId = (afId: string) => {
+            session.setExtraData(ContextKeys.ACCOUNTS_FILING_ID, afId);
+        };
+
+        beforeEach(() => {
+            jest.resetAllMocks();
+
+            service = new AccountsFilingService({
+                accountsFilingService: {
+                    setPackageAccountsType: mockSetPackageAccountsType
+                }
+            } as unknown as PrivateApiClient);
+
+
+            session = new Session();
+        });
+
+        it("should return nothing when successful", async () => {
+            mockTransactionId("tx_id");
+            mockaccountsFilingId("af_id");
+
+            mockSetPackageAccountsType.mockResolvedValue(new Success(undefined));
+
+            const returnValue = await service.setPackageAccountsType(session, "UKSEF");
+
+            expect(returnValue).toBeUndefined();
+        });
+
+        it("should throw an error if the transaction id is not in the session", async () => {
+            expect(() => {
+                return service.setPackageAccountsType(session, "UKSEF");
+            }).rejects.toThrow("Unable to find transactionId in session");
+        });
+
+        it("should throw an error if the accountsFilingId  is not in the session", async () => {
+            // Mock transaction ID so that it doesn
+            mockTransactionId("tx_id");
+
+            expect(() => {
+                return service.setPackageAccountsType(session, "UKSEF");
+            }).rejects.toThrow("Unable to find accountsFilingId in session");
+        });
+
+        it("should throw the returned error if there is any", async () => {
+            mockTransactionId("tx_id");
+            mockaccountsFilingId("af_id");
+
+            mockSetPackageAccountsType.mockResolvedValue(new Failure(new Error("Some error")));
+
+            expect(() => {
+                return service.setPackageAccountsType(session, "UKSEF");
+            }).rejects.toThrow("Some error");
+        });
+    });
 });


### PR DESCRIPTION
Add a call before the redirect to the account validator to set the package accounts type.
Currently it hard codes it to be "UKSEF".

Related `private-api-sdk-node` PR that adds the endpoint into the SDK: https://github.com/companieshouse/private-api-sdk-node/pull/122
Resolves: [AOAF-306](https://companieshouse.atlassian.net/browse/AOAF-306)

[AOAF-306]: https://companieshouse.atlassian.net/browse/AOAF-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ