### PR TITLE
Make call to close transaction with api key

### DIFF
--- a/src/services/external/transaction.service.ts
+++ b/src/services/external/transaction.service.ts
@@ -6,7 +6,7 @@ import { Session } from "@companieshouse/node-session-handler";
 import { getAccountsFilingId, getCompanyNumber, getTransactionId, must } from "../../utils/session";
 import { headers } from "../../utils/constants/headers";
 import { TRANSACTION_DESCRIPTION, TRANSACTION_REFERENCE, TransactionStatuses } from "../../utils/constants/transaction";
-import { makeApiCall } from "../../services/internal/api.client.service";
+import { makeApiCall, makeApiKeyCall } from "../../services/internal/api.client.service";
 
 
 export class TransactionService {
@@ -70,7 +70,7 @@ export class TransactionService {
         };
 
         logger.debug(`Updating transaction id ${transactionId} with company number ${companyNumber}, status ${transactionStatus}`);
-        const sdkResponse = await makeApiCall(this.session, async apiClient => {
+        const sdkResponse = await makeApiKeyCall(async apiClient => {
             return await apiClient.transaction.putTransaction(transaction);
         });
 

--- a/test/mocks/api.client.mock.ts
+++ b/test/mocks/api.client.mock.ts
@@ -13,5 +13,8 @@ jest.mock("../../src/services/internal/api.client.service", () => {
         makeApiCall: async (session: any, fn: any) => {
             return await fn(mockApiClient);
         },
+        makeApiKeyCall: async (fn: any) => {
+            return await fn(mockApiClient);
+        },
     };
 });


### PR DESCRIPTION
The transactions api uses the ERIC passthough header to make the call to the accounts-filing-api's validation-status endpoint. Since the cal was being made using OAUTH2, the passthrough token was also OAUTH2. However, the accounts-filing-api doesn't implenent OAUTH2 authentication leading to a 401 error reponse.
By chaging the request t close the transaction to be a call with the API key instead, the passthrough hader also uses API key authentication, and so is allowed by the accounts-filing-api service.