### PR TITLE
Call accounts filing on non internal api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.136",
+        "@companieshouse/api-sdk-node": "^2.0.154",
         "@companieshouse/node-session-handler": "^5.0.1",
         "@companieshouse/structured-logging-node": "^2.0.1",
         "@companieshouse/web-security-node": "^2.0.5",
@@ -18,7 +18,7 @@
         "govuk-frontend": "^4.7.0",
         "ioredis": "^5.3.2",
         "nunjucks": "^3.2.4",
-        "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#1.0.15",
+        "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#1.0.18",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -660,9 +660,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.153",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.153.tgz",
-      "integrity": "sha512-7+HpL8E3g3jPa96NAAtGOF2kzPQx5cW+7+tGvoAD1P0kjXAGOAxujAOTtoBWmbRRVvMcziTTb/nQw+Sg1D9/cg==",
+      "version": "2.0.154",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.154.tgz",
+      "integrity": "sha512-kj9BUnA0hwANyxkEVQ0SrYzv+QpEhZ4XFkvuSg/L14NOReGScVTOVjIyRsE1Xk8+ZkTZPsmxp9AN82a7PC2seQ==",
       "dependencies": {
         "axios": "^1.6.7",
         "camelcase-keys": "~6.2.2",
@@ -8500,11 +8500,11 @@
     },
     "node_modules/private-api-sdk-node": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#a673625e3e094188023dc87afe0bcc465b70a824",
+      "resolved": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#1401e1404fa9ad1ebfc96fbba80e0edb2949cfc7",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.135",
+        "@companieshouse/api-sdk-node": "^2.0.154",
         "@types/node": "~18.15.11",
         "camelcase-keys": "~6.2.2",
         "snakecase-keys": "~3.2.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.136",
+    "@companieshouse/api-sdk-node": "^2.0.154",
     "@companieshouse/node-session-handler": "^5.0.1",
     "@companieshouse/structured-logging-node": "^2.0.1",
     "@companieshouse/web-security-node": "^2.0.5",
@@ -74,7 +74,7 @@
     "govuk-frontend": "^4.7.0",
     "ioredis": "^5.3.2",
     "nunjucks": "^3.2.4",
-    "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#1.0.15",
+    "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#1.0.18",
     "uuid": "^9.0.1"
   },
   "overrides": {

--- a/src/routers/handlers/uploaded/uploaded.ts
+++ b/src/routers/handlers/uploaded/uploaded.ts
@@ -4,10 +4,10 @@ import { logger } from "../../../utils/logger";
 import { validate as uuidValidate } from "uuid";
 import { AccountsFilingService } from "../../../services/external/accounts.filing.service";
 import { AccountValidatorResponse } from "private-api-sdk-node/dist/services/account-validator/types";
-import { AccountsFilingValidationRequest } from "private-api-sdk-node/dist/services/accounts-filing/types";
 import { ContextKeys } from "../../../utils/constants/context.keys";
 import { setValidationResult } from "../../../utils/session";
 import { constructValidatorRedirect } from "../../../utils/url";
+import { AccountsFilingValidationRequest } from "@companieshouse/api-sdk-node/dist/services/accounts-filing/types";
 
 /**
  * Interface representing the view data for an uploaded file, extending from BaseViewData.

--- a/src/services/internal/api.client.service.ts
+++ b/src/services/internal/api.client.service.ts
@@ -132,7 +132,7 @@ export async function makeApiCall<T>(session: Session, fn: ApiClientCall<T>): Pr
 /**
  * Executes a given API call function using an API key-authorised API client.
  *
- * This function handles the creation of the ApiClient with the internal API key and then performs the API call by invoking the provided function `fn`.
+ * This function handles the creation of the ApiClient with the internal API key and then performs the API call by invoking the provided function `fn`. It is important to note that this function is designed to facilitate calls to the non-internal API, enabling external data access and operations.
  *
  * @param fn - A function that takes an ApiClient as an argument and returns a Promise of ApiResponse or ApiErrorResponse.
  * @returns The Promise of ApiResponse or ApiErrorResponse resulting from the API call function.

--- a/src/services/internal/api.client.service.ts
+++ b/src/services/internal/api.client.service.ts
@@ -4,7 +4,6 @@ import ApiClient from "@companieshouse/api-sdk-node/dist/client";
 import { createPrivateApiClient } from "private-api-sdk-node";
 import PrivateApiClient from "private-api-sdk-node/dist/client";
 import { createAndLogError, logger } from "../../utils/logger";
-import { ApiErrorResponse, ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { getAccessToken } from "../../utils/session";
 import { Session } from "@companieshouse/node-session-handler";
 
@@ -64,7 +63,7 @@ export function createApiKeyClient(): ApiClient {
     );
 }
 
-type ApiClientCall = (apiClient: ApiClient) => Promise<ApiResponse<unknown> | ApiErrorResponse>;
+type ApiClientCall<T> = (apiClient: ApiClient) => T;
 
 /**
  * Creates an instance of the API client using users OAuth tokens.
@@ -107,7 +106,7 @@ function maskString(s: string, n = 5, mask = "*"): string {
  * @param fn - A function that takes an ApiClient as an argument and returns a Promise of ApiResponse or ApiErrorResponse.
  * @returns The Promise of ApiResponse or ApiErrorResponse resulting from the API call function.
  */
-export async function makeApiCall(session: Session, fn: ApiClientCall): Promise<ApiResponse<unknown> | ApiErrorResponse> {
+export async function makeApiCall<T>(session: Session, fn: ApiClientCall<T>): Promise<T> {
     const client = createPublicOAuthApiClient(session);
 
     const response = await fn(client);
@@ -131,14 +130,14 @@ export async function makeApiCall(session: Session, fn: ApiClientCall): Promise<
 }
 
 /**
- * Executes a given API call function using an API key-authorized API client.
+ * Executes a given API call function using an API key-authorised API client.
  *
  * This function handles the creation of the ApiClient with the internal API key and then performs the API call by invoking the provided function `fn`.
  *
  * @param fn - A function that takes an ApiClient as an argument and returns a Promise of ApiResponse or ApiErrorResponse.
  * @returns The Promise of ApiResponse or ApiErrorResponse resulting from the API call function.
  */
-export async function makeApiKeyCall(fn: ApiClientCall): Promise<ApiResponse<unknown> | ApiErrorResponse> {
+export async function makeApiKeyCall<T>(fn: ApiClientCall<T>): Promise<T> {
     const client = createApiKeyClient();
 
     return await fn(client);

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -6,8 +6,7 @@ import { Session } from "@companieshouse/node-session-handler";
 import { ContextKeys } from "./constants/context.keys";
 import { createAndLogError } from "./logger";
 import { AccountValidatorResponse } from "private-api-sdk-node/dist/services/account-validator/types";
-import { PackageType } from "private-api-sdk-node/dist/services/accounts-filing/types";
-
+import { PackageType } from "@companieshouse/api-sdk-node/dist/services/accounts-filing/types";
 export function getSignInInfo(session: Session): ISignInInfo | undefined {
     return session?.data?.[SessionKey.SignInInfo];
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -2,7 +2,7 @@ import { Request } from 'express';
 import { env } from "../config";
 import { getCompanyNumber, getPackageType, must } from './session';
 import { PrefixedUrls, URL_QUERY_PARAM, fileIdPlaceholder } from './constants/urls';
-import { PackageType } from 'private-api-sdk-node/dist/services/accounts-filing/types';
+import { PackageType } from '@companieshouse/api-sdk-node/dist/services/accounts-filing/types';
 
 function constructRedirectUrl(base: string, queries: {[key: string]: string|PackageType}): string {
     const queryParams = Object.entries(queries).flatMap((value, _index) => {return `${value[0]}=${value[1]}`;}).join("&");

--- a/test/mocks/api.client.mock.ts
+++ b/test/mocks/api.client.mock.ts
@@ -2,8 +2,14 @@ export const mockApiClient = {
     transaction: {
         putTransaction: jest.fn(),
         postTransaction: jest.fn()
+    },
+    accountsFilingService: {
+        checkAccountsFileValidationStatus: jest.fn(),
+        confirmCompany: jest.fn(),
+        setPackageType: jest.fn(),
     }
 };
+
 export const mockCreatePublicOAuthApiClient = jest.fn();
 export const mockMakeApiCall = jest.fn();
 

--- a/test/routers/upload.unit.ts
+++ b/test/routers/upload.unit.ts
@@ -4,9 +4,9 @@ import { UploadHandler } from "../../src/routers/handlers/upload/upload";
 import { TransactionService as LocalTransactionService } from "../../src/services/external/transaction.service";
 
 import { accountsFilingServiceMock } from "../mocks/accounts.filing.service.mock";
-import { AccountsFilingCompanyResponse } from "private-api-sdk-node/dist/services/accounts-filing/types";
 import { ContextKeys } from "../../src/utils/constants/context.keys";
 import { getSessionRequest } from "../mocks/session.mock";
+import { AccountsFilingCompanyResponse } from "@companieshouse/api-sdk-node/dist/services/accounts-filing/types";
 
 let session = getSessionRequest();
 

--- a/test/services/external/accounts.filing.service.unit.ts
+++ b/test/services/external/accounts.filing.service.unit.ts
@@ -1,22 +1,8 @@
-import PrivateApiClient from 'private-api-sdk-node/dist/client';
+import { mockApiClient } from '../../mocks/api.client.mock';
 import { AccountsFilingService } from '../../../src/services/external/accounts.filing.service';
-import { Resource } from '@companieshouse/api-sdk-node';
-import { AccountsFileValidationResponse, AccountsFilingCompanyResponse, AccountsFilingValidationRequest, PackageType } from 'private-api-sdk-node/dist/services/accounts-filing/types';
-import { ApiErrorResponse } from '@companieshouse/api-sdk-node/dist/services/resource';
-import { Failure, Result, Success } from '@companieshouse/api-sdk-node/dist/services/result';
+import { Failure, Success } from '@companieshouse/api-sdk-node/dist/services/result';
 import { Session } from '@companieshouse/node-session-handler';
 import { ContextKeys } from '../../../src/utils/constants/context.keys';
-
-jest.mock('private-api-sdk-node/dist/client', () => {
-    return jest.fn().mockImplementation(() => {
-        return {
-            accountsFilingService: {
-                checkAccountsFileValidationStatus: jest.fn(),
-                confirmCompany: jest.fn()
-            }
-        };
-    });
-});
 
 function createApiResponse (fileId: string) {
     return {
@@ -41,26 +27,21 @@ function createApiResponse (fileId: string) {
         }
     };
 }
-// checkAccountsFileValidationStatus(fileValidationRequest: AccountsFilingValidationRequest): Promise<Resource<AccountsFileValidationResponse> | ApiErrorResponse>;
+
 describe('AccountsFilingService', () => {
     let service: AccountsFilingService;
-    const mockGetStatus = jest.fn<Promise<Resource<AccountsFileValidationResponse> | ApiErrorResponse>, [AccountsFilingValidationRequest]>();
 
     beforeEach(() => {
         jest.resetAllMocks();
 
-        service = new AccountsFilingService({
-            accountsFilingService: {
-                checkAccountsFileValidationStatus: mockGetStatus
-            }
-        } as unknown as PrivateApiClient);
+        service = new AccountsFilingService();
     });
 
     it('should successfully retrieve validation status for a valid request', async () => {
         const fileId = 'f2918b78-c344-4953-b8d1-20a6fce00267';
 
         const mockResponse = { httpStatusCode: 200, resource: createApiResponse(fileId) };
-        mockGetStatus.mockResolvedValue(mockResponse);
+        mockApiClient.accountsFilingService.checkAccountsFileValidationStatus.mockResolvedValue(mockResponse);
 
         const req = { fileId, transactionId: 'some id', accountsFilingId: 'some id' };
         await expect(service.getValidationStatus(req)).resolves.toEqual(mockResponse);
@@ -71,7 +52,7 @@ describe('AccountsFilingService', () => {
         const fileId = 'f2918b78-c344-4953-b8d1-20a6fce00267';
 
         const mockErrorResponse = { httpStatusCode: 400, errors: [{ error: 'Some error occurred' }] };
-        mockGetStatus.mockResolvedValue(mockErrorResponse);
+        mockApiClient.accountsFilingService.checkAccountsFileValidationStatus.mockResolvedValue(mockErrorResponse);
 
         const req = { fileId, transactionId: 'some id', accountsFilingId: 'some id' };
 
@@ -82,17 +63,11 @@ describe('AccountsFilingService', () => {
 
 describe('AccountsFilingService', () => {
     let service: AccountsFilingService;
-    const mockMyFunction = jest.fn<Promise<Resource<AccountsFilingCompanyResponse>>, [string, string]>();
 
     beforeEach(() => {
         jest.resetAllMocks();
 
-        service = new AccountsFilingService({
-            accountsFilingService: {
-                confirmCompany: mockMyFunction
-            }
-        } as unknown as PrivateApiClient);
-
+        service = new AccountsFilingService();
     });
 
     it('should return successfully 200', async () => {
@@ -103,7 +78,8 @@ describe('AccountsFilingService', () => {
                 accountsFilingId: "65e847f791418a767a51ce5d"
             }
         };
-        mockMyFunction.mockResolvedValue(mockResponse);
+
+        mockApiClient.accountsFilingService.confirmCompany.mockResolvedValue(mockResponse);
 
         const companyNumber = 'some id';
         const transactionId =  'some id';
@@ -111,14 +87,15 @@ describe('AccountsFilingService', () => {
         const companyConfirmRequest = {
             companyName
         };
-        await expect(service.checkCompany(companyNumber, transactionId, companyConfirmRequest)).resolves.toEqual(mockResponse);
+
+        const resp = await service.checkCompany(companyNumber, transactionId, companyConfirmRequest);
+        expect(resp).toEqual(mockResponse);
     });
 
 
     it('should throw an error for non-200 response', async () => {
-
         const mockErrorResponse = { httpStatusCode: 400, errors: [{ error: 'Some error occurred' }] };
-        mockMyFunction.mockResolvedValue(mockErrorResponse);
+        mockApiClient.accountsFilingService.confirmCompany.mockResolvedValue(mockErrorResponse);
 
         const companyNumber = 'some id';
         const transactionId =  'some id';
@@ -126,13 +103,13 @@ describe('AccountsFilingService', () => {
         const companyConfirmRequest = {
             companyName
         };
-        await expect(service.checkCompany(companyNumber, transactionId, companyConfirmRequest)).rejects.toEqual(mockErrorResponse);
+        const resp = service.checkCompany(companyNumber, transactionId, companyConfirmRequest);
+        expect(resp).rejects.toEqual(mockErrorResponse);
     });
 
 
     describe("AccountsFilingService.setPackageType tests", () => {
         let service: AccountsFilingService;
-        const mockSetPackageType = jest.fn<Promise<Result<void, Error>>, [string, string, PackageType]>();
         let session: Session;
 
         const mockTransactionId = (txId: string) => {
@@ -146,11 +123,7 @@ describe('AccountsFilingService', () => {
         beforeEach(() => {
             jest.resetAllMocks();
 
-            service = new AccountsFilingService({
-                accountsFilingService: {
-                    setPackageType: mockSetPackageType
-                }
-            } as unknown as PrivateApiClient);
+            service = new AccountsFilingService();
 
 
             session = new Session();
@@ -161,7 +134,7 @@ describe('AccountsFilingService', () => {
             mockTransactionId("tx_id");
             mockaccountsFilingId("af_id");
 
-            mockSetPackageType.mockResolvedValue(new Success(undefined));
+            mockApiClient.accountsFilingService.setPackageType.mockResolvedValue(new Success(undefined));
 
             const returnValue = await service.setTransactionPackageType(session);
 
@@ -187,7 +160,7 @@ describe('AccountsFilingService', () => {
             mockTransactionId("tx_id");
             mockaccountsFilingId("af_id");
 
-            mockSetPackageType.mockResolvedValue(new Failure(new Error("Some error")));
+            mockApiClient.accountsFilingService.setPackageType.mockResolvedValue(new Failure(new Error("Some error")));
 
             expect(() => {
                 return service.setTransactionPackageType(session);


### PR DESCRIPTION
Change the API calls to call on the external API instead of the internal API. 
Changed to use the public SDK instead of the private SDK,
Updated API calls to use function that uses external API. 
Fixed unit tests.

Related API change: https://github.com/companieshouse/accounts-filing-api/pull/71