### PR TITLE
Send the correct company name and number to transaction api

### DIFF
--- a/src/routers/handlers/upload/upload.ts
+++ b/src/routers/handlers/upload/upload.ts
@@ -23,8 +23,9 @@ export class UploadHandler extends GenericHandler {
         logger.info(`GET Request to send fileId call back address`);
 
         const companyNumber = must(getCompanyNumber(req.session));
+        const companyName = must(getCompanyName(req.session));
 
-        const transactionId = await this.callTransactionApi(companyNumber);
+        const transactionId = await this.callTransactionApi(companyNumber, companyName);
         req.session?.setExtraData(ContextKeys.TRANSACTION_ID, transactionId);
 
         if (transactionId === undefined) {
@@ -32,7 +33,6 @@ export class UploadHandler extends GenericHandler {
         }
 
         try {
-            const companyName = must(getCompanyName(req.session));
             const companyConfirmRequest = {
                 companyName
             };
@@ -62,9 +62,9 @@ export class UploadHandler extends GenericHandler {
         return constructValidatorRedirect(req);
     }
 
-    async callTransactionApi(companyNumber: string): Promise<string | undefined> {
+    async callTransactionApi(companyNumber: string, companyName: string): Promise<string | undefined> {
         try {
-            const transaction = await this.transactionService.postTransactionRecord(companyNumber, TRANSACTION_REFERENCE, TRANSACTION_DESCRIPTION);
+            const transaction = await this.transactionService.postTransactionRecord(companyNumber, companyName, TRANSACTION_REFERENCE, TRANSACTION_DESCRIPTION);
             return transaction.id;
         } catch (error) {
             logger.error(`Exception return from SDK while requesting creation of a transaction for company number [${companyNumber}].`);

--- a/src/services/external/transaction.service.ts
+++ b/src/services/external/transaction.service.ts
@@ -90,10 +90,16 @@ export class TransactionService {
     }
 
 
-    async postTransactionRecord(companyNumber: string, reference: string, description: string): Promise<Transaction> {
-        const transactionRecord = this.createTransactionRecord(companyNumber, reference, description);
+    async postTransactionRecord(companyNumber: string, companyName: string, reference: string, description: string): Promise<Transaction> {
+        
+        const transactionRecord : Transaction = {
+            companyNumber: companyNumber,
+            companyName: companyName,
+            description: description,
+            reference: reference
+        };
 
-        logger.debug(`Created Transaction Record using Company Number: ${companyNumber}, Reference: ${reference}, Description: ${description}`);
+        logger.debug(`Creating Transaction Record using Company Number: ${companyNumber}, Reference: ${reference}, Description: ${description}`);
 
         const transactionServiceResponse = await makeApiCall(this.session, async apiClient => {
             return await apiClient.transaction.postTransaction(transactionRecord);
@@ -105,16 +111,6 @@ export class TransactionService {
         }
 
         return getTransaction(transactionServiceResponse);
-    }
-
-    createTransactionRecord(companyNumber: string, reference: string, description: string): Transaction {
-        const transaction: Transaction = {
-            companyName: companyNumber,
-            description: description,
-            reference: reference
-
-        };
-        return transaction;
     }
 }
 

--- a/src/services/external/transaction.service.ts
+++ b/src/services/external/transaction.service.ts
@@ -91,8 +91,8 @@ export class TransactionService {
 
 
     async postTransactionRecord(companyNumber: string, companyName: string, reference: string, description: string): Promise<Transaction> {
-        
-        const transactionRecord : Transaction = {
+
+        const transactionRecord: Transaction = {
             companyNumber: companyNumber,
             companyName: companyName,
             description: description,

--- a/test/services/external/transaction.service.unit.ts
+++ b/test/services/external/transaction.service.unit.ts
@@ -151,6 +151,7 @@ describe("Put transaction tests", () => {
 
 function createApiResponse(
     companyNumber: string,
+    companyName: string,
     reference: string,
     description: string
 ) {
@@ -163,7 +164,7 @@ function createApiResponse(
         reference,
         status: "open",
         kind: "transaction",
-        companyName: undefined,
+        companyName,
         companyNumber,
         createdAt: "2000-01-01T13:00:00Z",
         createdBy: {
@@ -179,6 +180,7 @@ function createApiResponse(
 
 describe('TransactionService', () => {
     const companyNumber = "0";
+    const companyName = "Some Company";
     const reference = "accounts-filing-web";
     const description = "accounts filing web";
 
@@ -193,31 +195,31 @@ describe('TransactionService', () => {
     });
 
     it("should response when http code is 201", async () => {
-        const resource = createApiResponse(companyNumber, reference, description);
+        const resource = createApiResponse(companyNumber, companyName, reference, description);
         const mockResponse = { httpStatusCode: 201, resource };
         mockPostStatus.mockResolvedValue(mockResponse);
 
-        await expect(service.postTransactionRecord(companyNumber, reference, description)).resolves.toEqual(resource);
+        await expect(service.postTransactionRecord(companyNumber, companyName, reference, description)).resolves.toEqual(resource);
     });
 
     it("should throw error response when http code is 418", async () => {
         const mockErrorResponse = { httpStatusCode: 418, errors: [{ error: 'Some error occurred' }] };
         mockPostStatus.mockResolvedValue(mockErrorResponse);
 
-        await expect(service.postTransactionRecord(companyNumber, reference, description)).rejects.toEqual(mockErrorResponse);
+        await expect(service.postTransactionRecord(companyNumber, companyName, reference, description)).rejects.toEqual(mockErrorResponse);
     });
 
     it("should throw error when resource is undefined", async () => {
         const mockResponse = { httpStatusCode: 201, errors: [{ error: 'Some error occurred' }] };
         mockPostStatus.mockResolvedValue(mockResponse);
 
-        await expect(service.postTransactionRecord(companyNumber, reference, description)).rejects.toEqual(Error("Transaction service didn't return a resource"));
+        await expect(service.postTransactionRecord(companyNumber, companyName, reference, description)).rejects.toEqual(Error("Transaction service didn't return a resource"));
     });
 
     it("should throw error when resource obtains a undefined", async () => {
         const mockResponse = { httpStatusCode: 201, resource: undefined };
         mockPostStatus.mockResolvedValue(mockResponse);
 
-        await expect(service.postTransactionRecord(companyNumber, reference, description)).rejects.toEqual(Error("Transaction service return resource contains a undefined or null"));
+        await expect(service.postTransactionRecord(companyNumber, companyName, reference, description)).rejects.toEqual(Error("Transaction service return resource contains a undefined or null"));
     });
 });


### PR DESCRIPTION
This pr fixes the initial creation of the transaction so that it sends the correct company number and name to the transaction api. This will fix the issue of submission being rejected by chips for lack of company number.