### PR TITLE
Use oauth2 for all calls to apis

### DIFF
--- a/src/routers/file.uploaded.router.ts
+++ b/src/routers/file.uploaded.router.ts
@@ -1,7 +1,7 @@
 import { Request, Response, Router, NextFunction } from "express";
 import { UploadedHandler } from "./handlers/uploaded/uploaded";
 import { logger } from "../utils/logger";
-import { defaultAccountsFilingService } from "../services/external/accounts.filing.service";
+import { AccountsFilingService } from "../services/external/accounts.filing.service";
 import { handleExceptions } from "../utils/error.handler";
 
 const router: Router = Router();
@@ -31,7 +31,7 @@ router.get("/", (_req: Request, res: Response, _next: NextFunction) => {
 router.get("/:fileId", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
 
     logger.debug("Uploaded endpoint triggered.");
-    const handler = new UploadedHandler(defaultAccountsFilingService);
+    const handler = new UploadedHandler(new AccountsFilingService(req.session!));
     const viewData = await handler.executeGet(req, res);
 
     logger.debug(`Uploaded view data: ${JSON.stringify(viewData, null, 2)}`);

--- a/src/routers/upload.router.ts
+++ b/src/routers/upload.router.ts
@@ -2,13 +2,14 @@ import { Request, Response, Router, NextFunction } from "express";
 import { UploadHandler } from "./handlers/upload/upload";
 import { TransactionService } from "../services/external/transaction.service";
 import { handleExceptions } from "../utils/error.handler";
-import { defaultAccountsFilingService } from "../services/external/accounts.filing.service";
+import { AccountsFilingService } from "../services/external/accounts.filing.service";
 
 const router: Router = Router();
 
 router.get('/', handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
     const transactionService = new TransactionService(req.session!);
-    const uploadHandler = new UploadHandler(defaultAccountsFilingService, transactionService);
+    const accountsFilingService = new AccountsFilingService(req.session!);
+    const uploadHandler = new UploadHandler(accountsFilingService, transactionService);
     const validatorRedirectUrl = await uploadHandler.execute(req, res);
     res.redirect(validatorRedirectUrl);
 }));

--- a/src/services/external/accounts.filing.service.ts
+++ b/src/services/external/accounts.filing.service.ts
@@ -3,11 +3,13 @@ import { createAndLogError, logger } from "../../utils/logger";
 import { getAccountsFilingId, getPackageType, getTransactionId, must } from "../../utils/session";
 import { Session } from "@companieshouse/node-session-handler";
 import { AccountsFilingCompanyResponse, AccountsFilingValidationRequest, ConfirmCompanyRequest } from "@companieshouse/api-sdk-node/dist/services/accounts-filing/types";
-import { makeApiKeyCall } from "../../services/internal/api.client.service";
+import { makeApiCall } from "../../services/internal/api.client.service";
 import { AccountValidatorResponse } from "@companieshouse/api-sdk-node/dist/services/account-validator/types";
 
 
 export class AccountsFilingService {
+    constructor(private session: Session) {}
+
     /**
      * Asynchronously retrieves the validation status of an accounts filing request.
      *
@@ -21,7 +23,7 @@ export class AccountsFilingService {
         const fileId = req.fileId;
         logger.debug(`Getting validation status for file ${fileId}`);
 
-        const accountValidatorResponse = await makeApiKeyCall(async apiClient => {
+        const accountValidatorResponse = await makeApiCall(this.session, async apiClient => {
             return await apiClient.accountsFilingService.checkAccountsFileValidationStatus(req);
         });
 
@@ -52,7 +54,7 @@ export class AccountsFilingService {
         confirmCompanyRequest: ConfirmCompanyRequest
     ): Promise<Resource<AccountsFilingCompanyResponse>> {
 
-        const accountsFilingCompanyResponse = await makeApiKeyCall(async apiClient => {
+        const accountsFilingCompanyResponse = await makeApiCall(this.session, async apiClient => {
             return await apiClient.accountsFilingService.confirmCompany(
                 companyNumber,
                 transactionId,
@@ -96,7 +98,7 @@ export class AccountsFilingService {
             const accountsFilingId = must(getAccountsFilingId(session));
             const packageType = must(getPackageType(session));
 
-            const resp = await makeApiKeyCall(async apiClient => {
+            const resp = await makeApiCall(this.session, async apiClient => {
                 return await apiClient.accountsFilingService.setPackageType(transactionId, accountsFilingId, packageType);
             });
 
@@ -115,5 +117,3 @@ export class AccountsFilingService {
 function isResource(o: any): o is Resource<unknown> {
     return o !== null && o !== undefined && "resource" in o;
 }
-
-export const defaultAccountsFilingService = new AccountsFilingService();

--- a/src/services/external/transaction.service.ts
+++ b/src/services/external/transaction.service.ts
@@ -6,7 +6,7 @@ import { Session } from "@companieshouse/node-session-handler";
 import { getAccountsFilingId, getCompanyNumber, getTransactionId, must } from "../../utils/session";
 import { headers } from "../../utils/constants/headers";
 import { TRANSACTION_DESCRIPTION, TRANSACTION_REFERENCE, TransactionStatuses } from "../../utils/constants/transaction";
-import { makeApiCall, makeApiKeyCall } from "../../services/internal/api.client.service";
+import { makeApiCall } from "../../services/internal/api.client.service";
 
 
 export class TransactionService {
@@ -70,7 +70,7 @@ export class TransactionService {
         };
 
         logger.debug(`Updating transaction id ${transactionId} with company number ${companyNumber}, status ${transactionStatus}`);
-        const sdkResponse = await makeApiKeyCall(async apiClient => {
+        const sdkResponse = await makeApiCall(this.session, async apiClient => {
             return await apiClient.transaction.putTransaction(transaction);
         });
 

--- a/src/services/internal/api.client.service.ts
+++ b/src/services/internal/api.client.service.ts
@@ -1,9 +1,7 @@
 import { env } from "../../config";
 import { createApiClient } from "@companieshouse/api-sdk-node/dist";
 import ApiClient from "@companieshouse/api-sdk-node/dist/client";
-import { createPrivateApiClient } from "private-api-sdk-node";
-import PrivateApiClient from "private-api-sdk-node/dist/client";
-import { createAndLogError, logger } from "../../utils/logger";
+import { createAndLogError } from "../../utils/logger";
 import { getAccessToken } from "../../utils/session";
 import { Session } from "@companieshouse/node-session-handler";
 import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
@@ -27,45 +25,6 @@ export function createPublicOAuthApiClient(session: Session): ApiClient {
     throw createAndLogError("Error creating public OAuth API client. Unable to access OAuth token.");
 }
 
-
-/**
- * Creates an instance of the private API client using the CHS internal API key.
- *
- * @returns An instance of the private API client.
- */
-export function createPrivateApiKeyClient(): PrivateApiClient {
-    logger.info(
-        `Creating private API client with key ${maskString(
-            env.CHS_INTERNAL_API_KEY
-        )}`
-    );
-    return createPrivateApiClient(
-        env.CHS_INTERNAL_API_KEY,
-        undefined,
-        env.INTERNAL_API_URL
-    );
-}
-
-/**
- * Creates an instance of the ApiClient configured with the API key.
- * The API client facilitates interaction with the API by handling
- * requests and responses with the provided credentials and base URL.
- *
- * @returns {ApiClient} An instance of the ApiClient.
- */
-export function createApiKeyClient(): ApiClient {
-    logger.info(
-        `Creating API client with key ${maskString(
-            env.CHS_INTERNAL_API_KEY
-        )}`
-    );
-    return createApiClient(
-        env.CHS_INTERNAL_API_KEY,
-        undefined,
-        env.API_URL
-    );
-}
-
 type ApiClientCall<T> = (apiClient: ApiClient) => T;
 
 /**
@@ -79,23 +38,6 @@ export const createOAuthApiClient = (session: Session | undefined): ApiClient =>
     }
     return createApiClient(undefined, getAccessToken(session), env.API_URL);
 };
-
-/**
- * Masks a string by replacing characters after a specified position with a mask character.
- *
- * @param s - The input string to be masked.
- * @param n - The number of characters to preserve at the beginning of the string (default: 5).
- * @param mask - The character used for masking (default: '*').
- * @returns The masked string with characters after the specified position replaced by the mask character.
- *
- * @example
- * const input = "Hello, world!";
- * const masked = maskString(input);
- * console.log(masked); // Output: "Hello,******"
- */
-function maskString(s: string, n = 5, mask = "*"): string {
-    return [...s].map((char, index) => (index < n ? char : mask)).join("");
-}
 
 /**
  * Executes a given API call function using an OAuth authorized API client.
@@ -116,23 +58,6 @@ export async function makeApiCall<T>(session: Session, fn: ApiClientCall<T>): Pr
 
     return response;
 }
-
-/**
- * Executes a given API call function using an API key-authorised API client.
- *
- * This function handles the creation of the ApiClient with the internal API key and then performs the API call by invoking the provided function `fn`.
- * It is important to note that this function is designed to facilitate calls to the non-internal API, enabling external data access and operations.
- *
- * @param fn - A function that takes an ApiClient as an argument and returns a Promise of ApiResponse or ApiErrorResponse.
- * @returns The Promise of ApiResponse or ApiErrorResponse resulting from the API call function.
- */
-export async function makeApiKeyCall<T>(fn: ApiClientCall<T>): Promise<T> {
-    const client = createApiKeyClient();
-
-    return await fn(client);
-}
-
-export const defaultPrivateApiClient = createPrivateApiKeyClient();
 
 export const createPaymentApiClient = (session: Session, paymentUrl: string): ApiClient => {
     const oAuth = session.data?.[SessionKey.SignInInfo]?.[SignInInfoKeys.AccessToken]?.[AccessTokenKeys.AccessToken];

--- a/test/mocks/accounts.filing.service.mock.ts
+++ b/test/mocks/accounts.filing.service.mock.ts
@@ -1,13 +1,11 @@
-import { defaultAccountsFilingService } from "../../src/services/external/accounts.filing.service";
+export const mockAccountsFilingService = {
+    getValidationStatus: jest.fn(),
+    checkCompany: jest.fn(),
+    setTransactionPackageType: jest.fn()
+};
 
-defaultAccountsFilingService.checkCompany = jest.fn();
-
-export const mockDefaultAccountsFilingService = defaultAccountsFilingService as jest.Mocked<typeof defaultAccountsFilingService>;
-
-import PrivateApiClient from "private-api-sdk-node/dist/client";
-import { AccountsFilingService } from "../../src/services/external/accounts.filing.service";
-
-jest.mock("../../src/services/external/accounts.filing.service");
-
-export const accountsFilingServiceMock = new AccountsFilingService({} as PrivateApiClient) as jest.Mocked<AccountsFilingService>;
-
+jest.mock("../../src/services/external/accounts.filing.service", () => {
+    return {
+        AccountsFilingService: jest.fn().mockImplementation(() => mockAccountsFilingService)
+    }
+});

--- a/test/routers/handlers/upload/upload.unit.ts
+++ b/test/routers/handlers/upload/upload.unit.ts
@@ -1,5 +1,5 @@
 import { mockTransactionService } from "../../../mocks/transaction.service.mock";
-import { mockDefaultAccountsFilingService } from "../../../mocks/accounts.filing.service.mock";
+import { mockAccountsFilingService } from "../../../mocks/accounts.filing.service.mock";
 import { mockSession, resetMockSession } from "../../../mocks/session.middleware.mock";
 import { getSessionRequest } from "../../../mocks/session.mock";
 import request from "supertest";
@@ -26,7 +26,7 @@ describe("company auth test", () => {
         Object.assign(mockSession, getSessionRequest());
 
         mockTransactionService.postTransactionRecord.mockResolvedValue({ id: "1" });
-        mockDefaultAccountsFilingService.checkCompany.mockResolvedValue({
+        mockAccountsFilingService.checkCompany.mockResolvedValue({
             httpStatusCode: 200,
             resource: {
                 accountsFilingId: "1"

--- a/test/routers/handlers/uploaded/uploaded.unit.ts
+++ b/test/routers/handlers/uploaded/uploaded.unit.ts
@@ -1,7 +1,7 @@
 import { Request } from "express";
 import { UploadedHandler } from "../../../../src/routers/handlers/uploaded/uploaded";
 import { AccountValidatorResponse } from "private-api-sdk-node/dist/services/account-validator/types";
-import { accountsFilingServiceMock } from "../../../mocks/accounts.filing.service.mock";
+import { mockAccountsFilingService } from "../../../mocks/accounts.filing.service.mock";
 import { Session } from "@companieshouse/node-session-handler";
 import { ContextKeys } from "../../../../src/utils/constants/context.keys";
 
@@ -36,7 +36,7 @@ describe("UploadedHandler", () => {
     beforeEach(() => {
         jest.clearAllMocks();
 
-        handler = new UploadedHandler(accountsFilingServiceMock);
+        handler = new UploadedHandler(mockAccountsFilingService);
         mockReq = {
             params: { fileId: validUUIDv4 },
             session: session,
@@ -58,7 +58,7 @@ describe("UploadedHandler", () => {
     describe("execute method", () => {
         it("should call getValidationStatus with valid fileId", async () => {
             setRequestFileID(validUUIDv4);
-            accountsFilingServiceMock.getValidationStatus.mockResolvedValue({
+            mockAccountsFilingService.getValidationStatus.mockResolvedValue({
                 resource: {} as AccountValidatorResponse,
                 httpStatusCode: 200,
             });
@@ -71,7 +71,7 @@ describe("UploadedHandler", () => {
                 transactionId: "Placeholder transactionId",
             };
             expect(
-                accountsFilingServiceMock.getValidationStatus
+                mockAccountsFilingService.getValidationStatus
             ).toHaveBeenCalledWith(expectedCallValue);
         });
 
@@ -81,7 +81,7 @@ describe("UploadedHandler", () => {
                 resource: {} as AccountValidatorResponse,
                 httpStatusCode: 200,
             };
-            accountsFilingServiceMock.getValidationStatus.mockResolvedValue(
+            mockAccountsFilingService.getValidationStatus.mockResolvedValue(
                 mockResult
             );
 
@@ -96,7 +96,7 @@ describe("UploadedHandler", () => {
             await handler.executeGet(mockReq as Request, {} as any);
 
             expect(
-                accountsFilingServiceMock.getValidationStatus
+                mockAccountsFilingService.getValidationStatus
             ).not.toHaveBeenCalled();
         });
 

--- a/test/routers/upload.unit.ts
+++ b/test/routers/upload.unit.ts
@@ -3,7 +3,7 @@ import { Request } from "express";
 import { UploadHandler } from "../../src/routers/handlers/upload/upload";
 import { TransactionService as LocalTransactionService } from "../../src/services/external/transaction.service";
 
-import { accountsFilingServiceMock } from "../mocks/accounts.filing.service.mock";
+import { mockAccountsFilingService } from "../mocks/accounts.filing.service.mock";
 import { ContextKeys } from "../../src/utils/constants/context.keys";
 import { getSessionRequest } from "../mocks/session.mock";
 import { AccountsFilingCompanyResponse } from "@companieshouse/api-sdk-node/dist/services/accounts-filing/types";
@@ -49,7 +49,7 @@ describe("UploadHandler", () => {
         jest.resetAllMocks();
 
         handler = new UploadHandler(
-            accountsFilingServiceMock,
+            mockAccountsFilingService,
             {
                 postTransactionRecord: mockPostTransactionRecord
             } as unknown as LocalTransactionService);
@@ -87,13 +87,13 @@ describe("UploadHandler", () => {
 
         mockPostTransactionRecord.mockResolvedValue({ id: 1 } as unknown as Transaction);
 
-        accountsFilingServiceMock.checkCompany.mockResolvedValue(mockResult);
+        mockAccountsFilingService.checkCompany.mockResolvedValue(mockResult);
         const url = await handler.execute(mockReq as Request, {} as any);
 
         const expectedUrl =
             "http://chs.locl/xbrl_validate/submit?callback=http%3A%2F%2Fchs.local%2Faccounts-filing%2Fuploaded%2F%7BfileId%7D&backUrl=http%3A%2F%2Fchs.local%2Faccounts-filing%2Fchoose-your-accounts-package&packageType=uksef";
 
-        expect(accountsFilingServiceMock.checkCompany).toHaveBeenCalledTimes(1);
+        expect(mockAccountsFilingService.checkCompany).toHaveBeenCalledTimes(1);
         expect(url).toEqual(expectedUrl);
         expect(session.getExtraData(ContextKeys.ACCOUNTS_FILING_ID)).toEqual(
             mockResult.resource.accountsFilingId
@@ -107,7 +107,7 @@ describe("UploadHandler", () => {
         };
 
         mockPostTransactionRecord.mockResolvedValue({ id: 1 } as unknown as Transaction);
-        accountsFilingServiceMock.checkCompany.mockResolvedValue(
+        mockAccountsFilingService.checkCompany.mockResolvedValue(
             expectedResponse
         );
 


### PR DESCRIPTION
This pr changes all api calls in the service to use OAuth2. This is because: 
-It is the standard
-It will enable to confirmation email to work

This pr in linked to a permission change pr:
https://github.com/companieshouse/account.ch.gov.uk/pull/468
And a change to the api:
https://github.com/companieshouse/accounts-filing-api/pull/86