### PR TITLE
Node 20 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/local/configure-local-ssh
-FROM node:18-bookworm
+FROM node:20-bookworm
 
 COPY --from=0 ./ ./
 

--- a/ecs-image-build/Dockerfile
+++ b/ecs-image-build/Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE_VERSION="latest"
-FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-node-runtime-18:${IMAGE_VERSION} 
+FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-node-runtime-20:${IMAGE_VERSION} 
 
 WORKDIR /opt
 COPY /app .

--- a/test/mocks/accounts.filing.service.mock.ts
+++ b/test/mocks/accounts.filing.service.mock.ts
@@ -7,5 +7,5 @@ export const mockAccountsFilingService = {
 jest.mock("../../src/services/external/accounts.filing.service", () => {
     return {
         AccountsFilingService: jest.fn().mockImplementation(() => mockAccountsFilingService)
-    }
+    };
 });


### PR DESCRIPTION
This pr updates the docker base images for the local and ECS docker files. This is so the service builds in node 20 from now.

Also included is a small linting fix.

Resolves:
- AOAF-381