### PR TITLE
Send company number to account-validator

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,6 +1,6 @@
 import { Request } from 'express';
 import { env } from "../config";
-import { getPackageType, must } from './session';
+import { getCompanyNumber, getPackageType, must } from './session';
 import { PrefixedUrls, fileIdPlaceholder } from './constants/urls';
 import { PackageType } from '@companieshouse/api-sdk-node/dist/services/accounts-filing/types';
 
@@ -9,9 +9,8 @@ function constructRedirectUrl(base: string, queries: {[key: string]: string|Pack
     return `${base}?${queryParams}`;
 }
 
-function getRedirectUrl(callback: string, redirect: string, packageType: PackageType): string {
-    return constructRedirectUrl(env.SUBMIT_VALIDATION_URL, { callback, backUrl: redirect, packageType });
-
+function getRedirectUrl(callback: string, redirect: string, packageType: PackageType, companyNumber: string): string {
+    return constructRedirectUrl(env.SUBMIT_VALIDATION_URL, { callback, backUrl: redirect, packageType, companyNumber });
 }
 
 /**
@@ -23,13 +22,13 @@ function getUriHost(req: Request): string {
     return `${req.protocol}://${req.get('host')}`;
 }
 
-
 export function constructValidatorRedirect(req: Request): string{
     const base = getUriHost(req);
     const zipPortalCallbackUrl = encodeURIComponent(`${base}${PrefixedUrls.UPLOADED}/${fileIdPlaceholder}`);
     const xbrlValidatorBackUrl = encodeURIComponent(`${base}${PrefixedUrls.CHOOSE_YOUR_ACCOUNTS_PACKAGE}`);
     const packageType = must(getPackageType(req.session));
-    return getRedirectUrl(zipPortalCallbackUrl, xbrlValidatorBackUrl, packageType);
+    const companyNumber = must(getCompanyNumber(req.session));
+    return getRedirectUrl(zipPortalCallbackUrl, xbrlValidatorBackUrl, packageType, companyNumber);
 }
 
 export const getPaymentResourceUri = (transactionId: string): string => {

--- a/test/routers/upload.unit.ts
+++ b/test/routers/upload.unit.ts
@@ -90,7 +90,7 @@ describe("UploadHandler", () => {
         const url = await handler.execute(mockReq as Request, {} as any);
 
         const expectedUrl =
-            "http://chs.local/xbrl_validate/submit?callback=http%3A%2F%2Fchs.local%2Faccounts-filing%2Fuploaded%2F%7BfileId%7D&backUrl=http%3A%2F%2Fchs.local%2Faccounts-filing%2Fchoose-your-accounts-package&packageType=uksef";
+            "http://chs.local/xbrl_validate/submit?callback=http%3A%2F%2Fchs.local%2Faccounts-filing%2Fuploaded%2F%7BfileId%7D&backUrl=http%3A%2F%2Fchs.local%2Faccounts-filing%2Fchoose-your-accounts-package&packageType=uksef&companyNumber=123456";
 
         expect(mockAccountsFilingService.checkCompany).toHaveBeenCalledTimes(1);
         expect(url).toEqual(expectedUrl);


### PR DESCRIPTION
Pass company number to account validator so that it can be used to validate against the number returned from TNDP.

Related account-validator-web PR: https://github.com/companieshouse/account-validator-web/pull/122
Related account-validator-api PR: https://github.com/companieshouse/account-validator-api/pull/42

Resolves: [AOAF-466](https://companieshouse.atlassian.net/browse/AOAF-466)

[AOAF-466]: https://companieshouse.atlassian.net/browse/AOAF-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ