### PR TITLE
Flag group 400 uk package accounts option

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -32,6 +32,7 @@ export const env = readEnv(process.env, {
     DISABLE_AUDIT_EXEMPT_SUBSIDIARY_ACCOUNTS_RADIO: bool.describe('Flag to disable Audit Exempt subsidiary accounts'),
     DISABLE_DORMANT_EXEMPT_SUBSIDIARY_ACCOUNTS_RADIO: bool.describe('Flag to disable Dormant exempt (Filing) subsidiary accounts'),
     DISABLE_OVERSEAS_COMPANY_ACCOUNTS_RADIO: bool.describe('Flag to disable Overseas company accounts'),
+    DISABLE_GROUP_SECTION_400_UK_PARENT_ACCOUNTS_RADIO: bool.describe('Flag to disable Group - section 400 parent incorporated under UK law accounts'),
     DISABLE_GROUP_SECTION_401_NON_UK_PARENT_ACCOUNTS_RADIO: bool.describe('Flag to disable Group - section 401 parent incorporated under non UK law accounts'),
     DISABLE_LIMITED_PARTNERSHIP_ACCOUNTS_RADIO: bool.describe('Flag to disable Limited Partnership accounts'),
     INTERNAL_API_URL: url.describe("Internal API base URL for internal service interaction"),

--- a/src/routers/handlers/choose_your_package_accounts/package.type.options.ts
+++ b/src/routers/handlers/choose_your_package_accounts/package.type.options.ts
@@ -47,7 +47,7 @@ export const packageTypeOptions = (req: Request): PackageTypeOption[] => [
     {
         name: "group-package-400",
         description: getLocalesField("group_package_accounts_400_description", req),
-        disabled: false,
+        disabled: env.DISABLE_GROUP_SECTION_400_UK_PARENT_ACCOUNTS_RADIO,
     },
     {
         name: "group-package-401",

--- a/test/global.setup.ts
+++ b/test/global.setup.ts
@@ -13,6 +13,7 @@ export default () => {
     process.env.DISABLE_AUDIT_EXEMPT_SUBSIDIARY_ACCOUNTS_RADIO = "false";
     process.env.DISABLE_DORMANT_EXEMPT_SUBSIDIARY_ACCOUNTS_RADIO = "false";
     process.env.DISABLE_OVERSEAS_COMPANY_ACCOUNTS_RADIO = "false";
+    process.env.DISABLE_GROUP_SECTION_400_UK_PARENT_ACCOUNTS_RADIO = "false";
     process.env.DISABLE_GROUP_SECTION_401_NON_UK_PARENT_ACCOUNTS_RADIO = "false";
     process.env.DISABLE_LIMITED_PARTNERSHIP_ACCOUNTS_RADIO = "false";
     process.env.FEEDBACK_LINK = "http://chs.local/feedback";

--- a/test/routers/choose.your.package.account.unit.ts
+++ b/test/routers/choose.your.package.account.unit.ts
@@ -84,6 +84,7 @@ describe("package account selection test", () => {
         ["audit-exempt", "DISABLE_AUDIT_EXEMPT_SUBSIDIARY_ACCOUNTS_RADIO", "audit-exempt-subsidiary"],
         ["filing-exempt", "DISABLE_DORMANT_EXEMPT_SUBSIDIARY_ACCOUNTS_RADIO", "filing-exempt-subsidiary"],
         ["overseas", "DISABLE_OVERSEAS_COMPANY_ACCOUNTS_RADIO", "overseas"],
+        ["group-package-400", "DISABLE_GROUP_SECTION_400_UK_PARENT_ACCOUNTS_RADIO", "group-package-400"],
         ["group-package-401", "DISABLE_GROUP_SECTION_401_NON_UK_PARENT_ACCOUNTS_RADIO", "group-package-401"],
         ["limited-partnership", "DISABLE_LIMITED_PARTNERSHIP_ACCOUNTS_RADIO", "limited-partnership"]
     ];


### PR DESCRIPTION
Adds a flag to disable group 400 UK package accounts submissions. 

- Adds variable to config.
- Reads config into radio button option to disable if true.
- Added to test case. 
- Added to test environment config.

Docker dev environment PR: https://github.com/companieshouse/docker-chs-development/pull/1374
CIDEV config PR: https://github.com/companieshouse/ecs-service-configs-dev/pull/657

Resolves: [AOAF-468](https://companieshouse.atlassian.net/browse/AOAF-468)

[AOAF-468]: https://companieshouse.atlassian.net/browse/AOAF-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ