### PR TITLE
Add chs route in to service

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,6 @@
             "cwd": "${workspaceRoot}",
             "console": "integratedTerminal",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "runtimeVersion": "18.16.1",
             "args": [
                 "--runInBand",
                 "${relativeFile}"
@@ -24,8 +23,8 @@
             "address": "localhost",
             "localRoot": "${workspaceFolder}",
             "name": "Attach to Remote",
-            "port": 9230,
-            "remoteRoot": "/opt",
+            "port": 9235,
+            "remoteRoot": "/app",
             "request": "attach",
             "sourceMaps": true,
             "skipFiles": [

--- a/src/router.dispatch.ts
+++ b/src/router.dispatch.ts
@@ -40,16 +40,20 @@ const routerDispatch = (app: Application) => {
     router.use(localeMiddleware);
     router.use(createLoggerMiddleware(env.APP_NAME));
     router.use(Urls.HOME, HomeRouter);
+    router.use(Urls.HOME_WITH_COMPANY_NUMBER, HomeRouter);
     router.use(Urls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS, BeforeYouFilePackageAccountsRouter);
-
+    
     // ------------- Enable login redirect -----------------
     const userAuthRegex = new RegExp("^/.+");
     router.use(userAuthRegex, sessionMiddleware(sessionStore));
-    router.use(userAuthRegex, authenticationMiddleware);
-    router.use(EnsureSessionCookiePresentMiddleware(COOKIE_CONFIG));
+    router.use(Urls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS_WITH_COMPANY_NUMBER, BeforeYouFilePackageAccountsRouter);
     // It is important that CSRF Protection follows the Session and urlencoded Middlewares
     router.use(CsrfProtectionMiddleware(csrfMiddlewareOptions));
     router.use(helmet(prepareCSPConfig(nonce)));
+    
+    router.use(EnsureSessionCookiePresentMiddleware(COOKIE_CONFIG));
+    router.use(userAuthRegex, authenticationMiddleware);
+
     router.use(Urls.CONFIRM_COMPANY, CompanyConfirmRouter);
     router.use(Urls.COMPANY_SEARCH, CompanySearchRouter);
     router.use(Urls.CHOOSE_YOUR_ACCOUNTS_PACKAGE, companyAuthenticationMiddleware, ChooseYourPackageAccountsRouter);

--- a/src/routers/before.you.file.package.accounts.router.ts
+++ b/src/routers/before.you.file.package.accounts.router.ts
@@ -2,12 +2,17 @@ import { Request, Response, Router } from "express";
 import { handleExceptions } from "../utils/error.handler";
 import { BeforeYouFilePackageAccountsHandler } from "./handlers/before_you_file_package_accounts/before.you.file.package.accounts";
 
-const router = Router();
+const router = Router({ mergeParams: true });
 
 router.get('/', handleExceptions(async (req: Request, res: Response) => {
     const handler = new BeforeYouFilePackageAccountsHandler();
     const { templatePath, viewData } = handler.execute(req, res);
     res.render(templatePath, viewData);
+}));
+
+router.post('/', handleExceptions(async (req, res) => {
+    const handler = new BeforeYouFilePackageAccountsHandler();
+    handler.executePost(req, res);
 }));
 
 export default router;

--- a/src/routers/before.you.file.package.accounts.router.ts
+++ b/src/routers/before.you.file.package.accounts.router.ts
@@ -12,7 +12,8 @@ router.get('/', handleExceptions(async (req: Request, res: Response) => {
 
 router.post('/', handleExceptions(async (req, res) => {
     const handler = new BeforeYouFilePackageAccountsHandler();
-    handler.executePost(req, res);
+    const { url } = await handler.executePost(req, res);
+    res.redirect(url);
 }));
 
 export default router;

--- a/src/routers/handlers/before_you_file_package_accounts/before.you.file.package.accounts.ts
+++ b/src/routers/handlers/before_you_file_package_accounts/before.you.file.package.accounts.ts
@@ -1,8 +1,10 @@
 import { Request, Response } from "express";
-import { BaseViewData, GenericHandler, ViewModel } from "./../generic";
+import { BaseViewData, GenericHandler, Redirect, ViewModel } from "./../generic";
 import { logger } from "../../../utils/logger";
 import { addLangToUrl, selectLang } from "../../../utils/localise";
 import { PrefixedUrls } from "../../../utils/constants/urls";
+import { ValidateCompanyNumberFormat } from "../../../utils/validate/validate.company.number";
+import { setExtraDataCompanyNumber } from "../../../utils/session";
 
 export class BeforeYouFilePackageAccountsHandler extends GenericHandler {
     static routeViews: string = "router_views/before_you_file_package_accounts/before_you_file_package_accounts";
@@ -15,9 +17,41 @@ export class BeforeYouFilePackageAccountsHandler extends GenericHandler {
         });
     }
 
-    execute (_req: Request, _res: Response): ViewModel<BaseViewData> {
+    private determineNextURL(req: Request): string {
+        const companyNumber = req.params.companyNumber as string | undefined;
+        if (companyNumber && ValidateCompanyNumberFormat.isValid(companyNumber)) {
+            const nextURL = `${PrefixedUrls.CONFIRM_COMPANY}?companyNumber=${companyNumber}`
+            return addLangToUrl(nextURL,
+                selectLang(req.query.lang)
+            );
+        }
+        return addLangToUrl(PrefixedUrls.COMPANY_SEARCH, selectLang(req.query.lang));
+    }
+
+    execute (req: Request, _res: Response): ViewModel<BaseViewData> {
         logger.info(`GET request to serve before you file package accounts page`);
-        this.baseViewData.nextURL = addLangToUrl(PrefixedUrls.COMPANY_SEARCH, selectLang(_req.query.lang));
-        return { templatePath: `${BeforeYouFilePackageAccountsHandler.routeViews}`, viewData: this.baseViewData };
+        return { 
+            templatePath: BeforeYouFilePackageAccountsHandler.routeViews, 
+            viewData: {
+                ...this.baseViewData,
+                nextURL: req.originalUrl as string, 
+            }
+        };
+    }
+
+    executePost(req: Request, res: Response) {
+        const companyNumber = req.params.companyNumber as string | undefined;
+        const companySearchUrl = addLangToUrl(PrefixedUrls.COMPANY_SEARCH, selectLang(req.query.lang));
+        if (companyNumber === undefined || !ValidateCompanyNumberFormat.isValid(companyNumber)) {
+            return res.redirect(companySearchUrl);
+        }
+
+        if (req.session === undefined) {
+            logger.error(`Error redirecting directly to choose accounts page. No session to store company number in. Redirecting to Company search`);
+            return res.redirect(companySearchUrl);
+        }
+
+        setExtraDataCompanyNumber(req.session, companyNumber);
+        return res.redirect(addLangToUrl(PrefixedUrls.CHOOSE_YOUR_ACCOUNTS_PACKAGE, selectLang(req.query.lang)));
     }
 }

--- a/src/routers/handlers/index/home.ts
+++ b/src/routers/handlers/index/home.ts
@@ -9,16 +9,20 @@ import { ValidateCompanyNumberFormat } from "../../../utils/validate/validate.co
 
 export class HomeHandler extends GenericHandler {
 
-    constructor (req: Request) {
+    constructor(req: Request) {
         super({
             title: getLocalesField("start_page_title", req),
             viewName: "home",
-            backURL: null,
-            nextURL: HomeHandler.determineNextURL(req)
+            backURL: null
         });
     }
 
-    private static determineNextURL(req: Request): string {
+    private isChsRouteIn(req: Request) {
+        const companyNumber = req.params.companyNumber as string | undefined;
+        return companyNumber !== undefined && ValidateCompanyNumberFormat.isValid(companyNumber);
+    }
+
+    private determineNextURL(req: Request): string {
         const companyNumber = req.params.companyNumber as string | undefined;
         if (companyNumber && ValidateCompanyNumberFormat.isValid(companyNumber)) {
             return addLangToUrl(
@@ -29,8 +33,7 @@ export class HomeHandler extends GenericHandler {
         return addLangToUrl(PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS, selectLang(req.query.lang));
     }
 
-
-    execute (req: Request, _res: Response): ViewModel<HomeViewData> {
+    execute(req: Request, _res: Response): ViewModel<HomeViewData> {
         const routeViews = "router_views/index";
         logger.info(`GET request to serve home page`);
 
@@ -44,12 +47,14 @@ export class HomeHandler extends GenericHandler {
             group_401_disabled: env.DISABLE_GROUP_SECTION_401_NON_UK_PARENT_ACCOUNTS_RADIO
         };
 
-        return { 
-            templatePath: `${routeViews}/home`, 
-            viewData: { 
-                ...this.baseViewData, 
-                fees, 
-                ...disablePackageInfo
+        return {
+            templatePath: `${routeViews}/home`,
+            viewData: {
+                ...this.baseViewData,
+                fees,
+                ...disablePackageInfo,
+                nextURL: this.determineNextURL(req),
+                isChsRouteIn: this.isChsRouteIn(req)
             }
         };
     }
@@ -57,4 +62,5 @@ export class HomeHandler extends GenericHandler {
 
 interface HomeViewData extends BaseViewData {
     fees: typeof fees
+    isChsRouteIn: boolean
 }

--- a/src/routers/handlers/index/home.ts
+++ b/src/routers/handlers/index/home.ts
@@ -22,7 +22,7 @@ export class HomeHandler extends GenericHandler {
         const companyNumber = req.params.companyNumber as string | undefined;
         if (companyNumber && ValidateCompanyNumberFormat.isValid(companyNumber)) {
             return addLangToUrl(
-                PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS_WITH_COMPANY_NUMBER.replace("{companyNumber}", companyNumber),
+                PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS_WITH_COMPANY_NUMBER.replace(":companyNumber", companyNumber),
                 selectLang(req.query.lang)
             );
         }

--- a/src/routers/handlers/index/home.ts
+++ b/src/routers/handlers/index/home.ts
@@ -5,6 +5,7 @@ import { fees } from "../../../utils/constants/fees";
 import { getLocalesField, addLangToUrl, selectLang } from "../../../utils/localise";
 import { PrefixedUrls } from "../../../utils/constants/urls";
 import { env } from "../../../config";
+import { ValidateCompanyNumberFormat } from "../../../utils/validate/validate.company.number";
 
 export class HomeHandler extends GenericHandler {
 
@@ -13,11 +14,23 @@ export class HomeHandler extends GenericHandler {
             title: getLocalesField("start_page_title", req),
             viewName: "home",
             backURL: null,
-            nextURL: addLangToUrl(PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS, selectLang(req.query.lang))
+            nextURL: HomeHandler.determineNextURL(req)
         });
     }
 
-    execute (_req: Request, _res: Response): ViewModel<HomeViewData> {
+    private static determineNextURL(req: Request): string {
+        const companyNumber = req.params.companyNumber as string | undefined;
+        if (companyNumber && ValidateCompanyNumberFormat.isValid(companyNumber)) {
+            return addLangToUrl(
+                PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS_WITH_COMPANY_NUMBER.replace("{companyNumber}", companyNumber),
+                selectLang(req.query.lang)
+            );
+        }
+        return addLangToUrl(PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS, selectLang(req.query.lang));
+    }
+
+
+    execute (req: Request, _res: Response): ViewModel<HomeViewData> {
         const routeViews = "router_views/index";
         logger.info(`GET request to serve home page`);
 
@@ -31,7 +44,14 @@ export class HomeHandler extends GenericHandler {
             group_401_disabled: env.DISABLE_GROUP_SECTION_401_NON_UK_PARENT_ACCOUNTS_RADIO
         };
 
-        return { templatePath: `${routeViews}/home`, viewData: { ...this.baseViewData, fees, ...disablePackageInfo } };
+        return { 
+            templatePath: `${routeViews}/home`, 
+            viewData: { 
+                ...this.baseViewData, 
+                fees, 
+                ...disablePackageInfo
+            }
+        };
     }
 }
 

--- a/src/routers/index.router.ts
+++ b/src/routers/index.router.ts
@@ -1,17 +1,14 @@
 import { Request, Response, Router } from "express";
 import { HomeHandler } from "./handlers/index/home";
 
-const router = Router();
+const router = Router({ mergeParams: true });
 
-function renderHomePage(req: Request, res: Response) {
+router.get("/",  (req: Request, res: Response) => {
     const handler = new HomeHandler(req);
     const params = handler.execute(req, res);
     if (params.templatePath && params.viewData) {
         res.render(params.templatePath, params.viewData);
     }
-}
-
-router.get("/",  renderHomePage);
-router.get("/company/:companyNumber",  renderHomePage);
+});
 
 export default router;

--- a/src/routers/index.router.ts
+++ b/src/routers/index.router.ts
@@ -1,9 +1,17 @@
-import { Request, Response, Router, NextFunction } from "express";
+import { Request, Response, Router } from "express";
 import { HomeHandler } from "./handlers/index/home";
 
-const router: Router = Router();
+const router = Router();
 
-router.get("/",  (req: Request, res: Response, _next: NextFunction) => {
+router.get("/",  (req: Request, res: Response) => {
+    const handler = new HomeHandler(req);
+    const params = handler.execute(req, res);
+    if (params.templatePath && params.viewData) {
+        res.render(params.templatePath, params.viewData);
+    }
+});
+
+router.get("/company/:companyNumber",  (req: Request, res: Response) => {
     const handler = new HomeHandler(req);
     const params = handler.execute(req, res);
     if (params.templatePath && params.viewData) {

--- a/src/routers/index.router.ts
+++ b/src/routers/index.router.ts
@@ -3,20 +3,15 @@ import { HomeHandler } from "./handlers/index/home";
 
 const router = Router();
 
-router.get("/",  (req: Request, res: Response) => {
+function renderHomePage(req: Request, res: Response) {
     const handler = new HomeHandler(req);
     const params = handler.execute(req, res);
     if (params.templatePath && params.viewData) {
         res.render(params.templatePath, params.viewData);
     }
-});
+}
 
-router.get("/company/:companyNumber",  (req: Request, res: Response) => {
-    const handler = new HomeHandler(req);
-    const params = handler.execute(req, res);
-    if (params.templatePath && params.viewData) {
-        res.render(params.templatePath, params.viewData);
-    }
-});
+router.get("/",  renderHomePage);
+router.get("/company/:companyNumber",  renderHomePage);
 
 export default router;

--- a/src/routers/index.router.ts
+++ b/src/routers/index.router.ts
@@ -3,7 +3,7 @@ import { HomeHandler } from "./handlers/index/home";
 
 const router = Router({ mergeParams: true });
 
-router.get("/",  (req: Request, res: Response) => {
+router.get("/", (req: Request, res: Response) => {
     const handler = new HomeHandler(req);
     const params = handler.execute(req, res);
     if (params.templatePath && params.viewData) {

--- a/src/services/external/company.profile.service.ts
+++ b/src/services/external/company.profile.service.ts
@@ -2,13 +2,14 @@ import { Resource } from "@companieshouse/api-sdk-node";
 import ApiClient from "@companieshouse/api-sdk-node/dist/client";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile";
 import { logger } from "../../utils/logger";
-
+import { createOAuthApiClient } from "../internal/api.client.service";
+import { setCompanyName } from "../../utils/session";
+import { Request } from "express";
 
 export class CompanyProfileService {
     constructor(private apiClient: ApiClient) {}
 
     async getCompanyProfile(requestedCompanyNumber: string): Promise<CompanyProfile> {
-
         const companyProfile: Resource<CompanyProfile> = await this.apiClient.companyProfile.getCompanyProfile(requestedCompanyNumber);
         if (companyProfile.httpStatusCode !== 200) {
             logger.error(`Company Profile has return http status of ${companyProfile.httpStatusCode}`);
@@ -23,4 +24,11 @@ export class CompanyProfileService {
         return companyProfile.resource;
     }
 
+}
+
+export function getCompanyProfile(req: Request, companyNumber: string) {
+    const oauthApiClient = createOAuthApiClient(req.session);
+    const companyProfileService = new CompanyProfileService(oauthApiClient);
+
+    return companyProfileService.getCompanyProfile(companyNumber);
 }

--- a/src/utils/constants/urls.ts
+++ b/src/utils/constants/urls.ts
@@ -18,6 +18,7 @@ export const Urls = {
     CHECK_YOUR_ANSWERS: "/check-your-answers",
     PAYMENT: "/payment",
     BEFORE_YOU_FILE_PACKAGE_ACCOUNTS: "/before-you-file-package-accounts",
+    BEFORE_YOU_FILE_PACKAGE_ACCOUNTS_WITH_COMPANY_NUMBER: "/company/{companyNumber}/before-you-file-package-accounts",
     CHOOSE_YOUR_ACCOUNTS_PACKAGE: "/choose-your-accounts-package",
     PAYMENT_CALLBACK: "/payment-callback"
 } as const;

--- a/src/utils/constants/urls.ts
+++ b/src/utils/constants/urls.ts
@@ -9,16 +9,18 @@ export enum URL_QUERY_PARAM {
 // Object containing the pages Urls within the service
 export const Urls = {
     HOME: "/",
+    HOME_WITH_COMPANY_NUMBER: "/company/:companyNumber",
     HEALTHCHECK: "/healthcheck",
     CONFIRMATION: "/confirmation-submission",
     COMPANY_SEARCH: '/company-search',
     CONFIRM_COMPANY: '/confirm-company',
+    CONFIRM_COMPANY_CONTINUE_TO_ACCOUNTS_CHOOSER: '/confirm-company/continue',
     UPLOAD: "/upload",
     UPLOADED: "/uploaded",
     CHECK_YOUR_ANSWERS: "/check-your-answers",
     PAYMENT: "/payment",
     BEFORE_YOU_FILE_PACKAGE_ACCOUNTS: "/before-you-file-package-accounts",
-    BEFORE_YOU_FILE_PACKAGE_ACCOUNTS_WITH_COMPANY_NUMBER: "/company/{companyNumber}/before-you-file-package-accounts",
+    BEFORE_YOU_FILE_PACKAGE_ACCOUNTS_WITH_COMPANY_NUMBER: "/company/:companyNumber/before-you-file-package-accounts",
     CHOOSE_YOUR_ACCOUNTS_PACKAGE: "/choose-your-accounts-package",
     PAYMENT_CALLBACK: "/payment-callback"
 } as const;

--- a/src/views/router_views/before_you_file_package_accounts/before_you_file_package_accounts.njk
+++ b/src/views/router_views/before_you_file_package_accounts/before_you_file_package_accounts.njk
@@ -1,6 +1,7 @@
 {% extends "layouts/default.njk" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "web-security-node/components/csrf-token-input/macro.njk" import csrfTokenInput %}
 
 {% block main_content %}
 
@@ -17,14 +18,16 @@
         <li>{{ i18n.before_you_file_include_forms }}</li>
     </ul>
 
-    {{ govukButton({
-        text: i18n.continue,
-        href: nextURL,
-        classes: "",
-        isStartButton: false,
-        attributes: {
-            'data-event-id': 'package-accounts-before-file-package-page-continue'
-        }
-    }) }}
+    <form method="POST">
+        {{ govukButton({
+            text: i18n.continue,
+            classes: "",
+            isStartButton: false,
+            attributes: {
+                'data-event-id': 'package-accounts-before-file-package-page-continue'
+            },
+            type: "submit"
+        }) }}
+    </form>
 
 {% endblock %}

--- a/src/views/router_views/index/home.njk
+++ b/src/views/router_views/index/home.njk
@@ -55,7 +55,7 @@
         {{ i18n.start_page_timeout }}
     </p> 
     {{ govukButton({
-        text: i18n.start_now,
+        text: i18n.continue if isChsRouteIn else i18n.start_now,
         href: nextURL,
         classes: "govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8",
         isStartButton: true,

--- a/test/controllers/start.controller.unit.ts
+++ b/test/controllers/start.controller.unit.ts
@@ -50,7 +50,7 @@ describe("start controller tests", () => {
         const req = await request(app)
             .get(`${servicePathPrefix}/company/00006400`);
 
-        const expectedNextUrl = PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS_WITH_COMPANY_NUMBER.replace('{companyNumber}', '00006400');
+        const expectedNextUrl = PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS_WITH_COMPANY_NUMBER.replace(':companyNumber', '00006400');
         expect(req.text).toContain(expectedNextUrl);
     });
 

--- a/test/controllers/start.controller.unit.ts
+++ b/test/controllers/start.controller.unit.ts
@@ -1,7 +1,7 @@
 import { mockAuthenticationMiddleware } from "../mocks/all.middleware.mock";
 import request from "supertest";
 import app from "../../src/app";
-import { servicePathPrefix } from "../../src/utils/constants/urls";
+import { PrefixedUrls, servicePathPrefix } from "../../src/utils/constants/urls";
 
 describe("start controller tests", () => {
 
@@ -44,6 +44,14 @@ describe("start controller tests", () => {
             .get(servicePathPrefix + "?lang=cy");
 
         expect(req.text).toContain("Dolenni cymorth");
+    });
+
+    it("should route to the home page with a company number in the path", async () => {
+        const req = await request(app)
+            .get(`${servicePathPrefix}/company/00006400`);
+
+        const expectedNextUrl = PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS_WITH_COMPANY_NUMBER.replace('{companyNumber}', '00006400');
+        expect(req.text).toContain(expectedNextUrl);
     });
 
 });

--- a/test/mocks/company.profile.service.mock.ts
+++ b/test/mocks/company.profile.service.mock.ts
@@ -6,13 +6,14 @@ jest.mock('../../src/services/external/company.profile.service', () => {
                 getCompanyProfile: mockGetCompanyProfile
             };
         }),
+
+        getCompanyProfile: jest.fn()
     };
 });
 jest.mock("../../src/services/external/company.profile.service");
 
-import { CompanyProfileService } from '../../src/services/external/company.profile.service';
+import { CompanyProfileService, getCompanyProfile } from '../../src/services/external/company.profile.service';
 import ApiClient from '@companieshouse/api-sdk-node/dist/client';
 
-
 export const companyProfileServiceMock = new CompanyProfileService({} as ApiClient) as jest.Mocked<CompanyProfileService>;
-
+export const mockGetCompanyProfileFn = getCompanyProfile as jest.Mock

--- a/test/routers/before.you.file.package.accounts.unit.ts
+++ b/test/routers/before.you.file.package.accounts.unit.ts
@@ -1,6 +1,10 @@
 import app from "../../src/app";
 import request from "supertest";
 import { PrefixedUrls } from "../../src/utils/constants/urls";
+import { mockSession } from "../mocks/session.middleware.mock";
+import { getSessionRequest } from "../mocks/session.mock";
+import { getCompanyNumber, getCompanyNumberFromExtraData } from "../../src/utils/session";
+import { mock } from "node:test";
 
 describe("Before you file package accounts test", () => {
     it("Should render the page on get request", async () => {
@@ -33,5 +37,19 @@ describe("Welsh Cookie translation", () => {
     it("should have `Cookies on Companies House services` beforeYouFilePackageAccounts page", async() => {
         const resp = await request(app).get(PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS + "?lang=en");
         expect(resp.text).toContain("Cookies on Companies House services");
+    });
+});
+
+
+describe("CHS route tests", () => {
+    beforeEach(async () => {
+        Object.assign(mockSession, getSessionRequest());
+    });
+    
+    it('it should store the company number in the session and route to the select accounts type page', async () => {
+        const url = PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS_WITH_COMPANY_NUMBER.replace(':companyNumber', '00006400');
+        const resp = await request(app).post(url);
+        expect(getCompanyNumberFromExtraData(mockSession)).toBe('00006400');
+        expect(resp.headers.location).toContain(PrefixedUrls.CHOOSE_YOUR_ACCOUNTS_PACKAGE);
     });
 });

--- a/test/routers/before.you.file.package.accounts.unit.ts
+++ b/test/routers/before.you.file.package.accounts.unit.ts
@@ -1,10 +1,10 @@
+import { mockGetCompanyProfileFn } from "../mocks/company.profile.service.mock";
 import app from "../../src/app";
 import request from "supertest";
 import { PrefixedUrls } from "../../src/utils/constants/urls";
 import { mockSession } from "../mocks/session.middleware.mock";
 import { getSessionRequest } from "../mocks/session.mock";
-import { getCompanyNumber, getCompanyNumberFromExtraData } from "../../src/utils/session";
-import { mock } from "node:test";
+import { getCompanyNumberFromExtraData } from "../../src/utils/session";
 
 describe("Before you file package accounts test", () => {
     it("Should render the page on get request", async () => {
@@ -44,6 +44,10 @@ describe("Welsh Cookie translation", () => {
 describe("CHS route tests", () => {
     beforeEach(async () => {
         Object.assign(mockSession, getSessionRequest());
+        mockGetCompanyProfileFn.mockResolvedValue({
+            company_number: '00006400',
+            name: 'Test Company'
+        });
     });
     
     it('it should store the company number in the session and route to the select accounts type page', async () => {


### PR DESCRIPTION
Adds an entry point into the service from company accounts web that allows bypassing the company lookup screen since that will already be selected and authenticated on that service.

- Change start button to say 'Continue' instead of 'Start' when coming from company accounts web
- Add optional path parameter 'companyNumber' for the home screen that will persist to the 'Before you file' screem
- Add optional 'companyNumber' parameter to the 'Before you file screen.
- Add POST endpoint to the 'Before you file' screen to allow handling of company data or redirecting to company lookup depending on whether the route is from company accounts web or not. 
- On POST save company number, company name in session and redirect to package accounts chooser page.
- Set back button to return to 'Before you file' if following the company accounts journey.

Resolves: [AOAF-567](https://companieshouse.atlassian.net/browse/AOAF-567)

[AOAF-567]: https://companieshouse.atlassian.net/browse/AOAF-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ