### PR TITLE
Fix session variables not being reset

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -25,6 +25,9 @@ export const env = readEnv(process.env, {
     COOKIE_DOMAIN: str.describe('Domain for cookies'),
     COOKIE_NAME: str.describe('Name for the cookie'),
     COOKIE_SECRET: str.describe('Secret used for cookie encryption'),
+    COOKIE_SECURE_FLAG: bool
+        .describe('Flag to set the "Secure" attribute on cookies, ensuring they are only transmitted over HTTPS')
+        .default(true),
     DEVELOPERS_LINK: str
         .describe("Link for developers")
         .default("https://developer.companieshouse.gov.uk/"),

--- a/src/middleware/session.middleware.ts
+++ b/src/middleware/session.middleware.ts
@@ -1,17 +1,11 @@
 import { SessionMiddleware, SessionStore } from "@companieshouse/node-session-handler";
 import { env } from "../config";
 
-const COOKIE_DOMAIN = env.COOKIE_DOMAIN;
-const COOKIE_NAME = env.COOKIE_NAME;
-const COOKIE_SECRET = env.COOKIE_SECRET;
-
-
 export const COOKIE_CONFIG = {
-    cookieDomain: COOKIE_DOMAIN,
-    cookieName: COOKIE_NAME,
-    cookieSecret: COOKIE_SECRET,
-    cookieSecureFlag: undefined,
-    cookieTimeToLiveInSeconds: undefined
+    cookieDomain: env.COOKIE_DOMAIN,
+    cookieName: env.COOKIE_NAME,
+    cookieSecret: env.COOKIE_SECRET,
+    cookieSecureFlag: env.COOKIE_SECURE_FLAG
 };
 
 

--- a/src/router.dispatch.ts
+++ b/src/router.dispatch.ts
@@ -24,8 +24,6 @@ import helmet from "helmet";
 import { csrfErrorHandler } from "./routers/handlers/errors/csrf.error";
 import { createLoggerMiddleware } from "@companieshouse/structured-logging-node";
 
-
-
 const routerDispatch = (app: Application) => {
     // Use a sub-router to place all routes on a path-prefix
     const router = Router();

--- a/src/routers/handlers/before_you_file_package_accounts/before.you.file.package.accounts.ts
+++ b/src/routers/handlers/before_you_file_package_accounts/before.you.file.package.accounts.ts
@@ -4,7 +4,7 @@ import { logger } from "../../../utils/logger";
 import { addLangToUrl, selectLang } from "../../../utils/localise";
 import { PrefixedUrls } from "../../../utils/constants/urls";
 import { ValidateCompanyNumberFormat } from "../../../utils/validate/validate.company.number";
-import { setCompanyName, setExtraDataCompanyNumber, setIsChsJourney } from "../../../utils/session";
+import { clearSession, setCompanyName, setExtraDataCompanyNumber, setIsChsJourney } from "../../../utils/session";
 import { getCompanyProfile } from "../../../services/external/company.profile.service";
 
 export class BeforeYouFilePackageAccountsHandler extends GenericHandler {
@@ -31,6 +31,10 @@ export class BeforeYouFilePackageAccountsHandler extends GenericHandler {
     }
 
     async executePost(req: Request, _res: Response): Promise<Redirect> {
+        // Reset journey-specific session variables to prevent data persistence issues
+        // This ensures a clean slate if a user restarts the journey after partial completion
+        clearSession(req.session);
+
         const companyNumber = req.params.companyNumber as string | undefined;
         const companySearchUrl = addLangToUrl(PrefixedUrls.COMPANY_SEARCH, selectLang(req.query.lang));
         if (companyNumber === undefined || !ValidateCompanyNumberFormat.isValid(companyNumber)) {

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -189,3 +189,28 @@ export function getUserEmail(session: Session | undefined): string | Error {
         "Unable to find email in session"
     );
 }
+
+/**
+ * Clears journey-specific variables from the session.
+ *
+ * This function resets various session data to ensure a clean slate for the user's journey.
+ * It's particularly useful when a user needs to restart a process or begin a new journey
+ * to prevent any lingering data from causing unexpected behavior.
+ *
+ * @param {Session | undefined} session - The session object to be cleared.
+ * @throws {Error} If the session is undefined.
+ */
+export function clearSession(session: Session | undefined): void {
+    if (!session) {
+        throw createAndLogError("Unable to clear session as session is undefined");
+    }
+
+    session.deleteExtraData(ContextKeys.TRANSACTION_ID);
+    session.deleteExtraData(ContextKeys.ACCOUNTS_FILING_ID);
+    deleteValidationResult(session);
+    session.deleteExtraData(ContextKeys.PACKAGE_TYPE);
+    session.deleteExtraData(ContextKeys.COMPANY_NAME);
+    session.deleteExtraData(ContextKeys.COMPANY_NUMBER);
+    session.deleteExtraData(ContextKeys.LANGUAGE);
+    session.deleteExtraData(ContextKeys.IS_CHS_JOURNEY);
+}

--- a/test/utils/session.unit.ts
+++ b/test/utils/session.unit.ts
@@ -1,6 +1,7 @@
 import { Session } from '@companieshouse/node-session-handler';
 import { getSessionRequest, testAccessToken } from '../mocks/session.mock';
-import { getSignInInfo, getAccessToken } from "../../src/utils/session";
+import { getSignInInfo, getAccessToken, clearSession } from "../../src/utils/session";
+import { ContextKeys } from '../../src/utils/constants/context.keys';
 
 describe('SessionUtils test suite', () => {
     const testSessionRequest: Session = getSessionRequest();
@@ -13,5 +14,32 @@ describe('SessionUtils test suite', () => {
     it('Test function getAccessToken()', () => {
         const signInInfo = getAccessToken(testSessionRequest);
         expect(signInInfo).toEqual(testAccessToken.access_token);
+    });
+
+    describe('clearSession', () => {
+        let mockSession: Session;
+
+        beforeEach(() => {
+            mockSession = {
+                deleteExtraData: jest.fn(),
+                getExtraData: jest.fn()
+            } as unknown as Session;
+        });
+
+        it('should clear all specified session data', () => {
+            clearSession(mockSession);
+
+            expect(mockSession.deleteExtraData).toHaveBeenCalledWith(ContextKeys.TRANSACTION_ID);
+            expect(mockSession.deleteExtraData).toHaveBeenCalledWith(ContextKeys.ACCOUNTS_FILING_ID);
+            expect(mockSession.deleteExtraData).toHaveBeenCalledWith(ContextKeys.PACKAGE_TYPE);
+            expect(mockSession.deleteExtraData).toHaveBeenCalledWith(ContextKeys.COMPANY_NAME);
+            expect(mockSession.deleteExtraData).toHaveBeenCalledWith(ContextKeys.COMPANY_NUMBER);
+            expect(mockSession.deleteExtraData).toHaveBeenCalledWith(ContextKeys.LANGUAGE);
+            expect(mockSession.deleteExtraData).toHaveBeenCalledWith(ContextKeys.IS_CHS_JOURNEY);
+        });
+
+        it('should throw an error if session is undefined', () => {
+            expect(() => clearSession(undefined)).toThrow('Unable to clear session as session is undefined');
+        });
     });
 });


### PR DESCRIPTION
If a user completes part of a journey and then restarts then it is possible for session values from the previous journey to cause errors in the next one. This PR fixes that by resetting the journey-specific session variables after the "Before you file" page. 

Additionally, there was a bug with the session handler not setting cookies due to the secure flag being set. Since the local environment uses HTTP and not HTTPS the cookie was not being set leading to a redirect loop. To fix this, an environment variable `COOKIE_SECURE_FLAG` has been added which defaults to `true`, but can be set to false in environments that use HTTP.

This has been added to `docker-chs-development` in [this pr](https://github.com/companieshouse/docker-chs-development/pull/1557).