### PR TITLE
fix layout of signout-bar on accounts submitted page

### DIFF
--- a/src/views/partials/signout-bar.njk
+++ b/src/views/partials/signout-bar.njk
@@ -2,11 +2,13 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
         <a class="govuk-back-link {{ 'govuk-visually-hidden' if title == 'Accounts Submitted' }}" href="{{ backURL }}" data-event-id="{{backButtonDataEventId | replace(" ", "-")}}">{{i18n.back}}</a>
+        <ul class="{{ 'govuk-visually-hidden' if title != 'Accounts Submitted' }}"><ul>
     </div>
     {% set email = userEmail | default("Not signed in") %}
     <div class="govuk-grid-column-one-half govuk-!-text-align-right govuk-!-static-margin-top-3">
         <span class="govuk-body-s govuk-!-margin-2" id="signed-in-user">{{ email }}</span>
         <a class="govuk-link" href="{{ signoutURL }}" data-event-id="signout" id="user-signout">{{i18n.sign_out}}</a>
+        <ul class="{{ 'govuk-visually-hidden' if title != 'Accounts Submitted' }}"><ul>
     </div>
 </div>
 <div class="govuk-section-break govuk-section-break--visible"></div>


### PR DESCRIPTION
When the back button is hidden, the position of the email and sign out button changes. I've made updates to the signout bar to keep then in the same place when the back button is hidden.