### PR TITLE
Fix incorrect translation

### DIFF
--- a/locales/cy/before-file-package-accounts.json
+++ b/locales/cy/before-file-package-accounts.json
@@ -1,4 +1,4 @@
 {
-    "before_you_file_heading": "Cyn i chi ffeiio cyfrifon pecyn",
+    "before_you_file_heading": "Cyn i chi ffeilio cyfrifon pecyn",
     "before_you_file_body": "Mae'n rhaid eich bod wedi paratoi eich cyfrifon pecyn gan ddefnyddio meddalwedd addas. Rhaid cadw'r cyfrifon mewn fformat ffeil ZIP."
 }

--- a/src/routers/handlers/check_your_answers/check.your.answers.ts
+++ b/src/routers/handlers/check_your_answers/check.your.answers.ts
@@ -10,7 +10,7 @@ import { getAccountsFilingId, getTransactionId } from "../../../utils/session";
 import { startPaymentsSession } from "../../../services/external/payment.service";
 import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { Payment } from "@companieshouse/api-sdk-node/dist/services/payment";
-import { getLocalesField, selectLang } from "../../../utils/localise";
+import { getLocalesField } from "../../../utils/localise";
 
 interface CheckYourAnswersViewData extends BaseViewData {
     fileName: string

--- a/test/routers/before.you.file.package.accounts.unit.ts
+++ b/test/routers/before.you.file.package.accounts.unit.ts
@@ -22,7 +22,7 @@ describe("Before you file package accounts test", () => {
 describe("Welsh translation", () => {
     it("should translate `Support link` to Welsh for beforeYouFilePackageAccounts page", async () => {
         const resp = await request(app).get(PrefixedUrls.BEFORE_YOU_FILE_PACKAGE_ACCOUNTS + "?lang=cy");
-        expect(resp.text).toContain("Cyn i chi ffeiio cyfrifon pecyn");
+        expect(resp.text).toContain("Cyn i chi ffeilio cyfrifon pecyn");
     });
 });
 


### PR DESCRIPTION
This pull request makes a minor correction to the Welsh translation in the `locales/cy/before-file-package-accounts.json` file, fixing a spelling error in the heading text.