### PR TITLE
Fix translation issues

### DIFF
--- a/locales/cy/start-page.json
+++ b/locales/cy/start-page.json
@@ -16,7 +16,7 @@
     "start_page_find_software_link": "ddod o hyd i feddalwedd ar gyfer ffeilio cyfrifon cwmni.",
     "start_page_youll_need": "Bydd angen:",
     "start_page_youll_need_zip_file": "ffeil ZIP eich cyfrifon pecyn",
-    "start_page_youll_need_signin": "Mewngofnodi neu greu manylion mewngofnodi",
+    "start_page_youll_need_signin": "mewngofnodi neu greu cyfrif Tŷ'r Cwmnïau",
     "start_page_youll_need_company_name": "enw neu rif y cwmni",
     "start_page_youll_need_code": "cod dilysu'r cwmni",
     "start_page_youll_need_payment": "talu'r ffi gan ddefnyddio cerdyn credyd neu ddebyd, os yw'n berthnasol",


### PR DESCRIPTION
This pull request updates the Welsh translation for the sign-in requirement on the start page to use more accurate language.

* Localization update:
  * [`locales/cy/start-page.json`](diffhunk://#diff-6fe6a5f741bb511112076fad8d1831b933e76fbfce2084e1ee91263c19e7145cL19-R19): Changed the translation for "sign in or create an account" to specify "create a Companies House account" instead of "create sign-in details."