### PR TITLE
Fix punctuation errors

### DIFF
--- a/locales/en/start-page.json
+++ b/locales/en/start-page.json
@@ -13,7 +13,7 @@
     "start_page_400": "group package accounts - section 400, parent incorporated under UK law",
     "start_page_401": "group package accounts - section 401, parent incorporated under non-UK law",
     "start_page_welsh": "Welsh accounts with an English translation",
-    "start_page_find_software_link": "find software for filing company accounts",
+    "start_page_find_software_link": "find software for filing company accounts.",
     "start_page_youll_need": "You'll need:",
     "start_page_youll_need_zip_file": "the package accounts ZIP file",
     "start_page_youll_need_signin": "to sign in or create sign in details",

--- a/src/views/router_views/index/home.njk
+++ b/src/views/router_views/index/home.njk
@@ -11,7 +11,7 @@
             {{ i18n.start_page_what_youll_need_body }}
         </p>
         <p class="govuk-body">
-            {{ i18n.start_page_pre_find_software_link }} <a href="https://www.gov.uk/software-company-accounts" data-event-id="package-accounts-start-page-find-software-link">{{i18n.start_page_find_software_link}}</a>.
+            {{ i18n.start_page_pre_find_software_link }} <a href="https://www.gov.uk/software-company-accounts" data-event-id="package-accounts-start-page-find-software-link">{{i18n.start_page_find_software_link}}</a>
         </p>
     {% endset %}
 
@@ -61,7 +61,7 @@
 
     <p class="govuk-body">
         {{ i18n.start_page_timeout }}
-    </p> 
+    </p>
     {{ govukButton({
         text: i18n.continue if isChsRouteIn else i18n.file_package_accounts,
         href: nextURL,


### PR DESCRIPTION
This pull request makes a minor text update to the start page, ensuring consistency in punctuation for the "find software for filing company accounts" link. The change adds a period at the end of the link text in the English locale file, but removes the period after the link in the template to avoid double punctuation. No functional or structural changes are introduced.