### PR TITLE
Fix translation issues

### DIFF
--- a/locales/cy/start-page.json
+++ b/locales/cy/start-page.json
@@ -16,7 +16,7 @@
     "start_page_find_software_link": "ddod o hyd i feddalwedd ar gyfer ffeilio cyfrifon cwmni.",
     "start_page_youll_need": "Bydd angen:",
     "start_page_youll_need_zip_file": "ffeil ZIP eich cyfrifon pecyn",
-    "start_page_youll_need_signin": "mewngofnodi neu greu cyfrif Tŷ'r Cwmnïau",
+    "start_page_youll_need_signin": "mewngofnodi neu greu manylion mewngofnodi",
     "start_page_youll_need_company_name": "enw neu rif y cwmni",
     "start_page_youll_need_code": "cod dilysu'r cwmni",
     "start_page_youll_need_payment": "talu'r ffi gan ddefnyddio cerdyn credyd neu ddebyd, os yw'n berthnasol",


### PR DESCRIPTION
This pull request makes a minor update to the Welsh translation on the start page. The text for signing in has been changed to use a more general phrase for login details.

* Changed the translation for `start_page_youll_need_signin` in `locales/cy/start-page.json` to "mewngofnodi neu greu manylion mewngofnodi" for improved clarity.