### PR TITLE
Fix language persistence for upload and package types

### DIFF
--- a/src/routers/handlers/check_your_answers/check.your.answers.ts
+++ b/src/routers/handlers/check_your_answers/check.your.answers.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { GenericHandler, LocalizedViewData } from "./../generic";
 import { createAndLogError, logger } from "../../../utils/logger";
 import { TransactionService } from "../../../services/external/transaction.service";
-import { PrefixedUrls, Urls } from "../../../utils/constants/urls";
+import { PrefixedUrls } from "../../../utils/constants/urls";
 import { getPackageType, getUserEmail, getValidationResult, must } from "../../../utils/session";
 import { packageTypeOption } from "../choose_your_package_accounts/package.type.options";
 import { Session } from "@companieshouse/node-session-handler";

--- a/src/routers/handlers/check_your_answers/check.your.answers.ts
+++ b/src/routers/handlers/check_your_answers/check.your.answers.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { GenericHandler, LocalizedViewData } from "./../generic";
 import { createAndLogError, logger } from "../../../utils/logger";
 import { TransactionService } from "../../../services/external/transaction.service";
-import { PrefixedUrls } from "../../../utils/constants/urls";
+import { PrefixedUrls, Urls } from "../../../utils/constants/urls";
 import { getPackageType, getUserEmail, getValidationResult, must } from "../../../utils/session";
 import { packageTypeOption } from "../choose_your_package_accounts/package.type.options";
 import { Session } from "@companieshouse/node-session-handler";
@@ -10,12 +10,13 @@ import { getAccountsFilingId, getTransactionId } from "../../../utils/session";
 import { startPaymentsSession } from "../../../services/external/payment.service";
 import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { Payment } from "@companieshouse/api-sdk-node/dist/services/payment";
-import { getLocalesField } from "../../../utils/localise";
+import { addLangToUrl, getLocalesField, selectLang } from "../../../utils/localise";
 
 interface CheckYourAnswersViewData extends LocalizedViewData {
     fileName: string
     typeOfAccounts: string
     changeTypeOfAccountsUrl: string
+    chooseYourAccountsPackageUrl: string
 }
 
 export class CheckYourAnswersHandler extends GenericHandler {
@@ -43,7 +44,8 @@ export class CheckYourAnswersHandler extends GenericHandler {
         return {
             ...this.baseViewData,
             title: getLocalesField("check_your_answers_title", req),
-            changeTypeOfAccountsUrl: `${PrefixedUrls.UPLOAD}`,
+            changeTypeOfAccountsUrl: addLangToUrl(PrefixedUrls.UPLOAD, selectLang(req.query.lang)),
+            chooseYourAccountsPackageUrl: addLangToUrl(PrefixedUrls.CHOOSE_YOUR_ACCOUNTS_PACKAGE, selectLang(req.query.lang)),
             fileName: validationStatus.fileName,
             typeOfAccounts: accountsTypeFullName
         };

--- a/src/views/router_views/check_your_answers/check_your_answers.njk
+++ b/src/views/router_views/check_your_answers/check_your_answers.njk
@@ -72,3 +72,4 @@
     </form>
 
 {% endblock %}
+

--- a/src/views/router_views/check_your_answers/check_your_answers.njk
+++ b/src/views/router_views/check_your_answers/check_your_answers.njk
@@ -23,7 +23,7 @@
             actions: {
               items: [
                 {
-                  href: Urls.CHOOSE_YOUR_ACCOUNTS_PACKAGE,
+                  href: chooseYourAccountsPackageUrl,
                   text: i18n.change,
                   visuallyHiddenText: "type of accounts",
                   attributes: {


### PR DESCRIPTION
This pull request updates the "Check Your Answers" page handler and view to ensure language selection is correctly reflected in navigation URLs. The main focus is to add language-awareness to the "Choose Your Accounts Package" and "Change Type of Accounts" links, improving the user experience for multi-language support.

**Localization improvements:**

* Updated the handler to generate `changeTypeOfAccountsUrl` and `chooseYourAccountsPackageUrl` with the selected language using `addLangToUrl` and `selectLang`, ensuring these URLs respect the user's language choice. [[1]](diffhunk://#diff-a26248ccacb66984c2ed5df0691794373fadbb5a3994807b3f5015aa8e995143L5-R19) [[2]](diffhunk://#diff-a26248ccacb66984c2ed5df0691794373fadbb5a3994807b3f5015aa8e995143L46-R48)
* Modified the view (`check_your_answers.njk`) to use the new `chooseYourAccountsPackageUrl` variable, so the rendered link includes the correct language parameter.